### PR TITLE
@sarah => Fix for crash with going to the email view controller in settings and back

### DIFF
--- a/Classes/Controllers/Settings/ARSettingsViewController.m
+++ b/Classes/Controllers/Settings/ARSettingsViewController.m
@@ -34,7 +34,7 @@ static const NSInteger kHeightOfSettingsCell = 130;
 @interface ARSettingsViewController ()
 @property (nonatomic, strong) NSUserDefaults *defaults;
 
-@property (nonatomic, weak) IBOutlet UITableViewCell *syncViewCell;
+@property (nonatomic, strong) IBOutlet UITableViewCell *syncViewCell;
 @property (nonatomic, weak) IBOutlet UILabel *syncStatusLabel;
 @property (nonatomic, weak) IBOutlet UILabel *syncStatusSubtitleLabel;
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,17 +1,17 @@
 PODS:
   - AFNetworking (1.3.4)
-  - Analytics/Core-iOS (1.11.9):
+  - Analytics/Core-iOS (1.12.5):
     - TRVSDictionaryWithCaseInsensitivity (= 0.0.2)
-  - Analytics/Segmentio (1.11.9):
+  - Analytics/Segmentio (1.12.5):
     - Analytics/Core-iOS
-  - ARAnalytics/CoreIOS (3.4.0)
-  - ARAnalytics/HockeyApp (3.4.0):
+  - ARAnalytics/CoreIOS (3.6.3)
+  - ARAnalytics/HockeyApp (3.6.3):
     - ARAnalytics/CoreIOS
-    - HockeySDK
-  - ARAnalytics/Intercom (3.4.0):
+    - HockeySDK-Source
+  - ARAnalytics/Intercom (3.6.3):
     - ARAnalytics/CoreIOS
     - Intercom
-  - ARAnalytics/Segmentio (3.4.0):
+  - ARAnalytics/Segmentio (3.6.3):
     - Analytics/Segmentio
     - ARAnalytics/CoreIOS
   - ARCollectionViewMasonryLayout (2.0.0)
@@ -47,10 +47,8 @@ PODS:
   - GHMarkdownParser (0.0.1)
   - GRMustache (7.3.0):
     - JRSwizzle (~> 1.0)
-  - HockeySDK (3.7.1):
-    - HockeySDK/AllFeaturesLib (= 3.7.1)
-  - HockeySDK/AllFeaturesLib (3.7.1)
-  - Intercom (2.2.3)
+  - HockeySDK-Source (3.7.1)
+  - Intercom (2.3.2)
   - ISO8601DateFormatter (0.7)
   - JLRoutes (1.5.2)
   - JRSwizzle (1.0)
@@ -70,7 +68,7 @@ PODS:
   - Reachability (3.1.1)
   - SDWebImage/Core (3.7.1)
   - SFHFKeychainUtils (0.0.1)
-  - Specta (1.0.2)
+  - Specta (1.0.3)
   - SSDataSources (0.8.2)
   - TPKeyboardAvoiding (1.2.4)
   - TRVSDictionaryWithCaseInsensitivity (0.0.2)
@@ -140,7 +138,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   ARAnalytics:
-    :commit: e9d3db1bbe7b1d4e9afebba77470ebb6724e4148
+    :commit: f6defc2570299d0233f6724e242b948cf5c1d436
     :git: https://github.com/orta/ARAnalytics
   ARGenericTableViewController:
     :commit: 5349bb7130eb4ccc848cd5788fe9f5fe17f675ba
@@ -160,8 +158,8 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   AFNetworking: cf8e418e16f0c9c7e5c3150d019a3c679d015018
-  Analytics: e0633a6f0cb89a27265d94b4c8f94a4c1054f39d
-  ARAnalytics: 1d8b27b698887df209c408d850b2c9fc4b4c1e12
+  Analytics: e1144eebecb3fa0b8b46fa2ef00dc6089f76dbb2
+  ARAnalytics: 6a45b9c4aeafb4d79298a5b17428c7a87185af87
   ARCollectionViewMasonryLayout: 164b82010cf8ec99bc7a38cffe59a179d7e5a116
   ARGenericTableViewController: 61a0897ba66c35111b5d1cc3b44884282bd3c1a5
   ARTiledImageView: 000af4093f9bdcd0f754e6ebd964c90641389f90
@@ -181,8 +179,8 @@ SPEC CHECKSUMS:
   Forgeries: 8a2ff88a8c05ac1b82488d1c47a154f8decf7bc8
   GHMarkdownParser: 8b1a0e1d0c28e15a2696030054fdd2aa1562b6da
   GRMustache: 6baee020c5644416c034f5afb1607f6219e7f753
-  HockeySDK: 77bb90b6484a3b742ccf32bcae247c0a0051a962
-  Intercom: a9349693dca9940f8ce4b6a7414bfc0b4dfb7156
+  HockeySDK-Source: d620f330b23691017c141de6e25e5cdc8c67848c
+  Intercom: 1cfe66f2d14ddc035a35740c24da3cb01f0361a3
   ISO8601DateFormatter: ab926648eebe497f4d167c0fd083992f959f1274
   JLRoutes: fc36fd38ab476d5ac3a6a84b05be60e4b1a2bc81
   JRSwizzle: dd5ead5d913a0f29e7f558200165849f006bb1e3
@@ -195,7 +193,7 @@ SPEC CHECKSUMS:
   Reachability: dd9aa4fb6667b9f787690a74f53cb7634ce99893
   SDWebImage: ed3095af2ff88b436426037444979b917f6c5575
   SFHFKeychainUtils: 9576b411a79a058f4d5381ace6f3242b9a62e664
-  Specta: 9cec98310dca411f7c7ffd6943552b501622abfe
+  Specta: cf3e4188cf35375c3ee2cd03f8db8f1f4ef98234
   SSDataSources: ec4bcbed5d5daed53646b5986085b576165a6472
   TPKeyboardAvoiding: 0a40dfbb0af7c8bdae1dd457496dccfd217d85f6
   TRVSDictionaryWithCaseInsensitivity: 51d2ccf52c6d645d27b63467a98fa02c556e01b0


### PR DESCRIPTION
This would in theory be replicated with this test:

``` objc
it(@"keeps track of its sync view", ^{
    ARSettingsViewController *settingsVC = [[ARSettingsViewController alloc] init];
    UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:settingsVC];

    UIWindow *window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 320, 320)];
    window.rootViewController = nav;
    [window makeKeyAndVisible];

    UIViewController *newVC = [[UIViewController alloc] init];
    [nav pushViewController:newVC animated:NO];


    expect(^{
        [settingsVC beginAppearanceTransition:YES animated:NO];
    }).toNot.raise(nil);
});
```

But I couldn't find a way to make it raise correctly in tests, so alas, opted to not include it.