### PR TITLE
@jory => Adds support for checking the amount of Artworks in the db

### DIFF
--- a/Artsy Folio.xcodeproj/project.pbxproj
+++ b/Artsy Folio.xcodeproj/project.pbxproj
@@ -384,6 +384,8 @@
 		60B6085A1A41847300C2BBE5 /* PhoneAddArtworksButton@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 60B608561A41847300C2BBE5 /* PhoneAddArtworksButton@2x.png */; };
 		60B6085B1A41847300C2BBE5 /* PhoneCreateAlbumButton@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 60B608571A41847300C2BBE5 /* PhoneCreateAlbumButton@2x.png */; };
 		60B687CE16087AE800820176 /* AREditableImageGridViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 60B687CD16087AE800820176 /* AREditableImageGridViewCell.m */; };
+		60B813921B8276CF0046A52C /* ARZeroStateMessageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60B813911B8276CF0046A52C /* ARZeroStateMessageViewController.m */; };
+		60B813941B8280370046A52C /* ARZeroStateMessageViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 60B813931B8280370046A52C /* ARZeroStateMessageViewControllerTests.m */; };
 		60B9492D15E5067700A09B84 /* ARDocumentContainerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60B9492C15E5067700A09B84 /* ARDocumentContainerViewController.m */; };
 		60B95A821AC5FB80008AF85E /* ARGroupedTableViewHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = 60B95A811AC5FB80008AF85E /* ARGroupedTableViewHeader.m */; };
 		60BA589E153C21D8005E0576 /* ARAlertViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60BA589C153C21D7005E0576 /* ARAlertViewController.m */; };
@@ -1179,6 +1181,9 @@
 		60B608571A41847300C2BBE5 /* PhoneCreateAlbumButton@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "PhoneCreateAlbumButton@2x.png"; sourceTree = "<group>"; };
 		60B687CC16087AE800820176 /* AREditableImageGridViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AREditableImageGridViewCell.h; sourceTree = "<group>"; };
 		60B687CD16087AE800820176 /* AREditableImageGridViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AREditableImageGridViewCell.m; sourceTree = "<group>"; };
+		60B813901B8276CF0046A52C /* ARZeroStateMessageViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARZeroStateMessageViewController.h; sourceTree = "<group>"; };
+		60B813911B8276CF0046A52C /* ARZeroStateMessageViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARZeroStateMessageViewController.m; sourceTree = "<group>"; };
+		60B813931B8280370046A52C /* ARZeroStateMessageViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARZeroStateMessageViewControllerTests.m; sourceTree = "<group>"; };
 		60B9492B15E5067700A09B84 /* ARDocumentContainerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARDocumentContainerViewController.h; sourceTree = "<group>"; };
 		60B9492C15E5067700A09B84 /* ARDocumentContainerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARDocumentContainerViewController.m; sourceTree = "<group>"; };
 		60B9493115E50AF900A09B84 /* ARDocumentContainer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARDocumentContainer.h; sourceTree = "<group>"; };
@@ -1881,6 +1886,7 @@
 				60FDF6DC1AEAA21800173E81 /* ARSearchViewControllerTests.m */,
 				839E42601B052DE800C4BF49 /* ARFolioMessageViewControllerTests.m */,
 				834BA69C1B4AE74F009D18F7 /* ARFolioImageMessageViewControllerTests.m */,
+				60B813931B8280370046A52C /* ARZeroStateMessageViewControllerTests.m */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -2800,6 +2806,8 @@
 				8356C1731B20A4A3000E03B5 /* ARFolioMessageViewController.xib */,
 				8350BF161B03DBF0006D42AC /* ARFolioMessageViewController.h */,
 				8350BF171B03DBF0006D42AC /* ARFolioMessageViewController.m */,
+				60B813901B8276CF0046A52C /* ARZeroStateMessageViewController.h */,
+				60B813911B8276CF0046A52C /* ARZeroStateMessageViewController.m */,
 			);
 			name = Messages;
 			sourceTree = "<group>";
@@ -3769,6 +3777,7 @@
 				60EB677D1959CD6B00C9FA72 /* ARManagedObject+ModelFromJSON.m in Sources */,
 				B3DBEDE8185AB4D400C345A1 /* ARImageThumbnailCreatorTests.m in Sources */,
 				60F5762A19647AE60042B8BF /* ARSyncViewControllerTests.m in Sources */,
+				60B813941B8280370046A52C /* ARZeroStateMessageViewControllerTests.m in Sources */,
 				60F1F1021B04ACB0004B6C7F /* ARPartnerFullMetadataDownloaderSpec.m in Sources */,
 				60327DF4198A5DE00075B399 /* ARTabbedViewControllerDataSource.m in Sources */,
 				60DED57D1975A72200853B78 /* ARImageViewCategoriesTests.m in Sources */,
@@ -3898,6 +3907,7 @@
 				60E452BD14A132B600EB5BFE /* ARSettingsDefaultsEditor.m in Sources */,
 				60E0358219B5F1CB006F7C1E /* _SyncLog.m in Sources */,
 				6055B7861872E2CC0043B937 /* AROptions.m in Sources */,
+				60B813921B8276CF0046A52C /* ARZeroStateMessageViewController.m in Sources */,
 				609991FD1A45BB2300741423 /* SubscriptionPlan.m in Sources */,
 				601E1A14194F86F9004B21E4 /* UIImage+ImageFromColor.m in Sources */,
 				6027A6DC14BB8C380020A592 /* User.m in Sources */,

--- a/ArtsyFolio Tests/Models/PartnerModelTests.m
+++ b/ArtsyFolio Tests/Models/PartnerModelTests.m
@@ -12,6 +12,26 @@ it(@"current partner gets first partner in context", ^{
     expect([Partner currentPartnerInContext:context]).to.equal(partner);
 });
 
+describe(@"has uploaded works on cms", ^{
+
+    it(@"returns false the partner's artwork count is 0", ^{
+        partner.artworksCount = @(0);
+        expect(partner.hasUploadedWorks).to.beFalsy();
+    });
+
+    it(@"returns true the partner's artwork count is > 0", ^{
+        partner.artworksCount = @(1);
+        expect(partner.hasUploadedWorks).to.beTruthy();
+    });
+
+    it(@"also takes into account the amount of artworks in the MOC", ^{
+        Artwork *artwork = [Artwork objectInContext:context];
+        partner.artworksCount = @(0);
+
+        expect(partner.hasUploadedWorks).to.beTruthy();
+    });
+});
+
 describe(@"partner type", ^{
     it(@"is collector for a collector type", ^{
         partner = [Partner modelFromJSON:@{ @"type" : @"Private Collector" } inContext:context];

--- a/ArtsyFolio Tests/View Controllers/ARZeroStateMessageViewControllerTests.m
+++ b/ArtsyFolio Tests/View Controllers/ARZeroStateMessageViewControllerTests.m
@@ -1,0 +1,49 @@
+#import "ARZeroStateMessageViewController.h"
+#import "ARSync.h"
+#import "ARBaseViewController+TransparentModals.h"
+
+@interface ARZeroStateMessageViewController () <ARSyncDelegate>
+@property (nonatomic, strong) ARSync *sync;
+@property (nonatomic, strong) NSManagedObjectContext *managedObjectContext;
+
+// I don't like doing this, but otherwise there's a lot of crazy hacking
+// to get a working UIWindow heirarchy.
+- (void)dismissSelf;
+
+@end
+
+SpecBegin(ARZeroStateMessageViewController)
+
+__block ARZeroStateMessageViewController *sut;
+
+before(^{
+    sut = [[ARZeroStateMessageViewController alloc] init];
+});
+
+it(@"runs a sync on the when tapping the retry button ", ^{
+    id syncMock = OCMClassMock(ARSync.class);
+    sut.sync = syncMock;
+
+    OCMExpect([(ARSync *)syncMock sync]);
+    sut.secondaryAction();
+
+    OCMVerifyAll(syncMock);
+});
+
+it(@"removes the overlay on a sync completion if partner has works", ^{
+    ARZeroStateMessageViewController *zeroVC = [[ARZeroStateMessageViewController alloc] init];
+    zeroVC.managedObjectContext = [CoreDataManager stubbedManagedObjectContext];
+
+    // Make the partner has work checks pass
+    id _ = [Partner modelFromJSON:@{} inContext:zeroVC.managedObjectContext];
+    _ = [Artwork modelFromJSON:@{} inContext:zeroVC.managedObjectContext];
+
+
+    id rootVCMock = OCMPartialMock(zeroVC);
+    OCMExpect([rootVCMock dismissSelf]);
+
+    [rootVCMock syncDidFinish:nil];
+    OCMVerifyAll(rootVCMock);
+});
+
+SpecEnd

--- a/Classes/ARInitialViewControllerSetupCoordinator.m
+++ b/Classes/ARInitialViewControllerSetupCoordinator.m
@@ -7,7 +7,7 @@
 #import "ARFolioMessageViewController.h"
 #import "ARBaseViewController+TransparentModals.h"
 #import "AROptions.h"
-
+#import "ARZeroStateMessageViewController.h"
 
 @interface ARInitialViewControllerSetupCoordinator ()
 @property (nonatomic, readonly, strong) ARSync *sync;
@@ -179,13 +179,7 @@
 
 - (void)presentZeroStateScreen
 {
-    ARFolioMessageViewController *zeroStateViewController = [[ARFolioMessageViewController alloc] init];
-
-    zeroStateViewController.messageText = NSLocalizedString(@"Your Folio experience begins with uploading works to your CMS.", @"Zero state title");
-    zeroStateViewController.callToActionText = NSLocalizedString(@"Once you've uploaded works, your inventory will be viewable here.", @"Zero state subtitle");
-    zeroStateViewController.buttonText = NSLocalizedString(@"Visit Your CMS", @"Visit CMS button title");
-    zeroStateViewController.callToActionAddress = @"https://cms.artsy.net";
-
+    ARZeroStateMessageViewController *zeroStateViewController = [[ARZeroStateMessageViewController alloc] init];
     [self.window.rootViewController presentTransparentModalViewController:zeroStateViewController animated:NO withAlpha:1];
 }
 

--- a/Classes/Categories/ARBaseViewController+TransparentModals.h
+++ b/Classes/Categories/ARBaseViewController+TransparentModals.h
@@ -1,8 +1,6 @@
 //  Based on http://stackoverflow.com/questions/849458/transparent-modal-view-on-navigation-controller
 
-#import "ARTopViewController.h"
 #import "ARAlertViewController.h"
-
 
 @interface UIViewController (TransparentModals)
 

--- a/Classes/Controllers/Login & Setup/ARFolioMessageViewController.xib
+++ b/Classes/Controllers/Login & Setup/ARFolioMessageViewController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7531" systemVersion="14F6a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7531" systemVersion="14F19a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7520"/>

--- a/Classes/Controllers/Login & Setup/ARZeroStateMessageViewController.h
+++ b/Classes/Controllers/Login & Setup/ARZeroStateMessageViewController.h
@@ -1,0 +1,5 @@
+#import "ARFolioMessageViewController.h"
+
+@interface ARZeroStateMessageViewController : ARFolioMessageViewController
+
+@end

--- a/Classes/Controllers/Login & Setup/ARZeroStateMessageViewController.m
+++ b/Classes/Controllers/Login & Setup/ARZeroStateMessageViewController.m
@@ -1,0 +1,57 @@
+#import "ARZeroStateMessageViewController.h"
+#import "ARBaseViewController+TransparentModals.h"
+#import "ARSync.h"
+
+@interface ARZeroStateMessageViewController () <ARSyncDelegate>
+@property (nonatomic, strong) ARSync *sync;
+@property (nonatomic, weak) IBOutlet UIButton *secondaryCallToActionButton;
+@property (nonatomic, strong) NSManagedObjectContext *managedObjectContext;
+
+@end
+
+@implementation ARZeroStateMessageViewController
+
+- (instancetype)init
+{
+    self = [super initWithNibName:@"ARFolioMessageViewController" bundle:nil];
+    if (!self) { return nil; }
+
+    self.messageText = NSLocalizedString(@"Your Folio experience begins with uploading works to your CMS.", @"Zero state title");
+    self.callToActionText = NSLocalizedString(@"Once you've uploaded works, your inventory will be viewable here.", @"Zero state subtitle");
+    self.buttonText = NSLocalizedString(@"Visit Your CMS", @"Visit CMS button title");
+    self.callToActionAddress = @"https://cms.artsy.net";
+    self.secondaryButtonText = @"RETRY";
+
+    __weak typeof(self) weakSelf = self;
+
+    self.secondaryAction = ^(){
+        weakSelf.secondaryCallToActionButton.enabled = NO;
+
+        weakSelf.sync = weakSelf.sync ?: [[ARSync alloc] init];
+        weakSelf.sync.delegate = weakSelf;
+        [weakSelf.sync sync];
+    };
+
+    return self;
+}
+
+- (void)syncDidFinish:(ARSync *)sync
+{
+    self.secondaryCallToActionButton.enabled = YES;
+
+    if ([Partner currentPartnerInContext:self.managedObjectContext].hasUploadedWorks) {
+        [self dismissSelf];
+    }
+}
+
+- (void)dismissSelf
+{
+    [self.view.window.rootViewController dismissTransparentModalViewControllerAnimated:YES];
+}
+
+- (NSManagedObjectContext *)managedObjectContext
+{
+    return _managedObjectContext ?: [CoreDataManager mainManagedObjectContext];
+}
+
+@end

--- a/Classes/Models/Partner.m
+++ b/Classes/Models/Partner.m
@@ -45,7 +45,7 @@
 
 - (BOOL)hasUploadedWorks
 {
-    return self.artworksCount.boolValue;
+    return self.artworksCount.boolValue || [Artwork countInContext:self.managedObjectContext error:nil];
 }
 
 - (BOOL)hasPublishedWorks


### PR DESCRIPTION
fixes #12 

Previously we would use a Partner's `artworks_count` data from the server to detect if we need to show a zero-state screen. Problem is, that is only updated once a day. So if you go from 0 -> X, then Folio didn't know.

So this PR adds the ability to run a re-sync from the zero-state screen, and will also query the internal Artworks database to see if we have some artworks.