### PR TITLE
@orta=>Revamped transparent modal animations

### DIFF
--- a/Classes/Categories/ARBaseViewController+TransparentModals.h
+++ b/Classes/Categories/ARBaseViewController+TransparentModals.h
@@ -2,17 +2,32 @@
 
 #import "ARAlertViewController.h"
 
+typedef NS_ENUM(NSInteger, ARTransparentModalAnimationStyle) {
+    ARTransparentModalAnimationStyleCrossDissolve,
+    ARTransparentModalAnimationStyleVerticalSpring,
+};
+
+
 @interface UIViewController (TransparentModals)
 
 - (void)setTransparentModalViewController:(UIViewController *)viewController;
 
 - (UIViewController *)transparentModalViewController;
 
+// legacy present method; defaults to vertical spring style
 - (void)presentTransparentModalViewController:(UIViewController *)aViewController
                                      animated:(BOOL)isAnimated
                                     withAlpha:(CGFloat)anAlpha;
 
+- (void)presentTransparentModalViewController:(UIViewController *)aViewController
+                                     animated:(BOOL)isAnimated
+                                    withAlpha:(CGFloat)anAlpha
+                                    withStyle:(ARTransparentModalAnimationStyle)style;
+
+// legacy dismiss method; defaults to vertical spring style
 - (void)dismissTransparentModalViewControllerAnimated:(BOOL)animated;
+
+- (void)dismissTransparentModalViewControllerAnimated:(BOOL)animated withStyle:(ARTransparentModalAnimationStyle)style;
 
 - (void)presentTransparentAlertWithText:(NSString *)text withOKAs:(NSString *)okText andCancelAs:(NSString *)cancel completion:(void (^)(enum ARModalAlertViewControllerStatus))completion;
 

--- a/Classes/Categories/ARBaseViewController+TransparentModals.m
+++ b/Classes/Categories/ARBaseViewController+TransparentModals.m
@@ -23,59 +23,7 @@
                                      animated:(BOOL)isAnimated
                                     withAlpha:(CGFloat)anAlpha
 {
-    self.transparentModalViewController = aViewController;
-    UIView *view = aViewController.view;
-
-    view.opaque = NO;
-    view.backgroundColor = [view.backgroundColor colorWithAlphaComponent:0];
-
-    if (isAnimated) {
-        CGRect mainrect = [self.view bounds];
-        CGRect newRect = CGRectMake(0, mainrect.size.height, mainrect.size.width, mainrect.size.height);
-
-        [self.view addSubview:view];
-        view.frame = newRect;
-
-        [UIView animateWithDuration:ARAnimationLongDuration delay:0 usingSpringWithDamping:0.7 initialSpringVelocity:0.5 options:UIViewAnimationOptionCurveEaseIn animations:^{
-            
-            view.frame = mainrect;
-            
-            if (self.navigationController) {
-                self.navigationController.navigationBar.alpha = 0.5;
-                self.navigationController.navigationBar.userInteractionEnabled = NO;
-            }
-
-        } completion:^(BOOL finished) {
-            [UIView animateWithDuration:ARAnimationQuickDuration animations:^{
-                view.backgroundColor = [view.backgroundColor colorWithAlphaComponent:anAlpha];
-            }];
-        }];
-
-    } else {
-        view.frame = [[UIScreen mainScreen] bounds];
-        view.backgroundColor = [view.backgroundColor colorWithAlphaComponent:anAlpha];
-        [self.view addSubview:view];
-    }
-}
-
-- (void)dismissTransparentModalViewControllerAnimated:(BOOL)animated
-{
-    UIView *view = self.transparentModalViewController.view;
-    view.backgroundColor = [view.backgroundColor colorWithAlphaComponent:0];
-
-    CGRect mainrect = [self.view bounds];
-    CGRect newRect = CGRectMake(0, mainrect.size.height, mainrect.size.width, mainrect.size.height);
-
-    [UIView animateIf:animated duration:ARAnimationDuration:^{
-        self.transparentModalViewController.view.frame = newRect;
-        if (self.navigationController) {
-            self.navigationController.navigationBar.alpha = 1;
-            self.navigationController.navigationBar.userInteractionEnabled = YES;
-        }
-    } completion:^(BOOL finished) {
-        [self.transparentModalViewController.view removeFromSuperview];
-        self.transparentModalViewController = nil;
-    }];
+    [self presentTransparentModalViewController:aViewController animated:isAnimated withAlpha:anAlpha withStyle:ARTransparentModalAnimationStyleVerticalSpring];
 }
 
 - (void)presentTransparentAlertWithText:(NSString *)text withOKAs:(NSString *)okText andCancelAs:(NSString *)cancel completion:(void (^)(enum ARModalAlertViewControllerStatus))completion
@@ -85,7 +33,138 @@
     alertVC.cancelTitle = cancel;
     alertVC.alertText = text;
 
-    [self presentTransparentModalViewController:alertVC animated:YES withAlpha:0.3];
+    [self presentTransparentModalViewController:alertVC animated:YES withAlpha:0.3 withStyle:ARTransparentModalAnimationStyleVerticalSpring];
+}
+
+- (void)presentTransparentModalViewController:(UIViewController *)aViewController
+                                     animated:(BOOL)isAnimated
+                                    withAlpha:(CGFloat)anAlpha
+                                    withStyle:(ARTransparentModalAnimationStyle)style
+{
+    self.transparentModalViewController = aViewController;
+    UIView *view = aViewController.view;
+
+    view.opaque = NO;
+    view.backgroundColor = [view.backgroundColor colorWithAlphaComponent:0];
+
+    if (isAnimated) {
+        [self.view addSubview:view];
+
+        switch (style) {
+            case ARTransparentModalAnimationStyleVerticalSpring:
+                [self presentModalWithVerticalSpring:view alpha:anAlpha];
+                break;
+            case ARTransparentModalAnimationStyleCrossDissolve:
+                [self presentModalWithCrossDissolve:view alpha:anAlpha];
+                break;
+        }
+
+    } else {
+        view.frame = [[UIScreen mainScreen] bounds];
+        view.backgroundColor = [view.backgroundColor colorWithAlphaComponent:anAlpha];
+        [self.view addSubview:view];
+    }
+}
+
+- (void)presentModalWithVerticalSpring:(UIView *)view alpha:(CGFloat)anAlpha
+{
+    CGRect mainrect = [self.view bounds];
+    CGRect newRect = CGRectMake(0, mainrect.size.height, mainrect.size.width, mainrect.size.height);
+    view.frame = newRect;
+
+    [UIView animateWithDuration:ARAnimationLongDuration delay:0 usingSpringWithDamping:0.7 initialSpringVelocity:0.5 options:UIViewAnimationOptionCurveEaseIn animations:^{
+
+        view.frame = mainrect;
+
+        if (self.navigationController) {
+            self.navigationController.navigationBar.alpha = 0.5;
+            self.navigationController.navigationBar.userInteractionEnabled = NO;
+        }
+
+    } completion:^(BOOL finished) {
+        view.backgroundColor = [view.backgroundColor colorWithAlphaComponent:anAlpha];
+    }];
+}
+
+- (void)presentModalWithCrossDissolve:(UIView *)view alpha:(CGFloat)anAlpha
+{
+    view.alpha = 0.0;
+
+    [UIView animateWithDuration:ARAnimationLongDuration animations:^{
+        view.alpha = 1.0;
+
+        if (self.navigationController) {
+            self.navigationController.navigationBar.alpha = 0.5;
+            self.navigationController.navigationBar.userInteractionEnabled = NO;
+        }
+    }];
+    view.backgroundColor = [view.backgroundColor colorWithAlphaComponent:anAlpha];
+}
+
+- (void)dismissTransparentModalViewControllerAnimated:(BOOL)animated
+{
+    [self dismissTransparentModalViewControllerAnimated:animated withStyle:ARTransparentModalAnimationStyleVerticalSpring];
+}
+
+- (void)dismissTransparentModalViewControllerAnimated:(BOOL)animated withStyle:(ARTransparentModalAnimationStyle)style
+{
+    void (^completion)() = ^{
+        [self.transparentModalViewController.view removeFromSuperview];
+        self.transparentModalViewController = nil;
+    };
+
+    if (animated) {
+        switch (style) {
+            case ARTransparentModalAnimationStyleVerticalSpring:
+                [self dismissModalVertically:completion];
+                break;
+            case ARTransparentModalAnimationStyleCrossDissolve:
+                [self dimissModalWithCrossDissolve:completion];
+                break;
+        }
+    } else {
+        if (self.navigationController) {
+            self.navigationController.navigationBar.alpha = 1;
+            self.navigationController.navigationBar.userInteractionEnabled = YES;
+        }
+        completion();
+    }
+}
+
+
+- (void)dismissModalVertically:(void (^)(void))completion
+{
+    UIView *view = self.transparentModalViewController.view;
+    view.backgroundColor = [view.backgroundColor colorWithAlphaComponent:0];
+
+    CGRect mainrect = [self.view bounds];
+    CGRect newRect = CGRectMake(0, mainrect.size.height, mainrect.size.width, mainrect.size.height);
+
+    [UIView animateWithDuration:ARAnimationDuration animations:^{
+        self.transparentModalViewController.view.frame = newRect;
+        if (self.navigationController) {
+            self.navigationController.navigationBar.alpha = 1;
+            self.navigationController.navigationBar.userInteractionEnabled = YES;
+        }
+    } completion:^(BOOL finished) {
+        completion();
+    }];
+}
+
+- (void)dimissModalWithCrossDissolve:(void (^)(void))completion
+{
+    UIView *view = self.transparentModalViewController.view;
+    view.backgroundColor = [view.backgroundColor colorWithAlphaComponent:0];
+
+    [UIView animateWithDuration:ARAnimationDuration animations:^{
+        view.alpha = 0.0;
+        if (self.navigationController) {
+            self.navigationController.navigationBar.alpha = 1;
+            self.navigationController.navigationBar.userInteractionEnabled = YES;
+        }
+    } completion:^(BOOL finished) {
+        completion();
+    }];
 }
 
 @end


### PR DESCRIPTION
I wanted to use this category for the settings panel but with cross-dissolve instead of the bouncy spring effect. 

You can now choose between the two or use the legacy method for the original springy one. I've verified that it works with the storyboard in my other PR.

![](http://media0.giphy.com/media/sKSth6sonAimk/giphy.gif)