### PR TITLE
[WIP] @orta=> Document thumbnail issue

### DIFF
--- a/Classes/Models/ArtistDocument.m
+++ b/Classes/Models/ArtistDocument.m
@@ -40,6 +40,12 @@
     return [ARFileUtils filePathWithFolder:folder documentFileName:self.filename];
 }
 
+- (NSString *)newThumbnailFilePath
+{
+    NSString *folder = [NSString stringWithFormat:@"%@/%@/thumbnails/", [Partner currentPartnerID], self.artist.slug];
+    return [ARFileUtils filePathWithFolder:folder documentFileName:[self.slug stringByAppendingPathExtension:@"jpg"]];
+}
+
 - (NSString *)thumbnailFilePath
 {
     NSString *folder = [NSString stringWithFormat:@"%@/%@/thumbnails/", [Partner currentPartnerID], self.artist.slug];

--- a/Classes/Models/ArtistDocument.m
+++ b/Classes/Models/ArtistDocument.m
@@ -40,7 +40,7 @@
     return [ARFileUtils filePathWithFolder:folder documentFileName:self.filename];
 }
 
-- (NSString *)newThumbnailFilePath
+- (NSString *)customThumbnailFilePath
 {
     NSString *folder = [NSString stringWithFormat:@"%@/%@/thumbnails/", [Partner currentPartnerID], self.artist.slug];
     return [ARFileUtils filePathWithFolder:folder documentFileName:[self.slug stringByAppendingPathExtension:@"jpg"]];
@@ -48,12 +48,10 @@
 
 - (NSString *)thumbnailFilePath
 {
-    NSString *folder = [NSString stringWithFormat:@"%@/%@/thumbnails/", [Partner currentPartnerID], self.artist.slug];
-    NSString *customThumbnailPath = [ARFileUtils filePathWithFolder:folder documentFileName:[self.slug stringByAppendingPathExtension:@"jpg"]];
-    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:customThumbnailPath];
+    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:customThumbnailFilePath];
 
     if (self.canGenerateThumbnail && fileExists) {
-        return customThumbnailPath;
+        return customThumbnailFilePath;
     } else {
         return [super thumbnailFilePath];
     }

--- a/Classes/Models/Document.h
+++ b/Classes/Models/Document.h
@@ -14,6 +14,7 @@
 
 - (BOOL)canGenerateThumbnail;
 - (NSString *)thumbnailFilePath;
+- (NSString *)newThumbnailFilePath;
 
 /// For showing to users
 - (NSString *)presentableFileName;

--- a/Classes/Models/Document.h
+++ b/Classes/Models/Document.h
@@ -14,7 +14,7 @@
 
 - (BOOL)canGenerateThumbnail;
 - (NSString *)thumbnailFilePath;
-- (NSString *)newThumbnailFilePath;
+- (NSString *)customThumbnailFilePath;
 
 /// For showing to users
 - (NSString *)presentableFileName;

--- a/Classes/Models/Document.m
+++ b/Classes/Models/Document.m
@@ -49,6 +49,11 @@
     }
 }
 
+- (NSString *)newThumbnailFilePath
+{
+    return [self thumbnailFilePath];
+}
+
 - (NSString *)genericTextDocumentFilePath
 {
     return [[NSBundle mainBundle] pathForResource:@"FileIcon_textdoc" ofType:@"png"];

--- a/Classes/Models/Document.m
+++ b/Classes/Models/Document.m
@@ -49,7 +49,7 @@
     }
 }
 
-- (NSString *)newThumbnailFilePath
+- (NSString *)customThumbnailFilePath
 {
     return [self thumbnailFilePath];
 }

--- a/Classes/Models/ShowDocument.m
+++ b/Classes/Models/ShowDocument.m
@@ -41,7 +41,7 @@
     return [ARFileUtils filePathWithFolder:folder documentFileName:self.filename];
 }
 
-- (NSString *)newThumbnailFilePath
+- (NSString *)customThumbnailFilePath
 {
     NSString *slug = [Partner currentPartnerID];
     NSString *folder = [NSString stringWithFormat:@"%@/%@/thumbnails/", slug, self.show.slug];
@@ -50,13 +50,10 @@
 
 - (NSString *)thumbnailFilePath
 {
-    NSString *slug = [Partner currentPartnerID];
-    NSString *folder = [NSString stringWithFormat:@"%@/%@/thumbnails/", slug, self.show.slug];
-    NSString *customThumbnailPath = [ARFileUtils filePathWithFolder:folder documentFileName:[self.slug stringByAppendingPathExtension:@"jpg"]];
-    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:customThumbnailPath];
+    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:customThumbnailFilePath];
 
     if (self.canGenerateThumbnail && fileExists) {
-        return customThumbnailPath;
+        return customThumbnailFilePath;
     } else {
         return [super thumbnailFilePath];
     }

--- a/Classes/Models/ShowDocument.m
+++ b/Classes/Models/ShowDocument.m
@@ -41,6 +41,13 @@
     return [ARFileUtils filePathWithFolder:folder documentFileName:self.filename];
 }
 
+- (NSString *)newThumbnailFilePath
+{
+    NSString *slug = [Partner currentPartnerID];
+    NSString *folder = [NSString stringWithFormat:@"%@/%@/thumbnails/", slug, self.show.slug];
+    return [ARFileUtils filePathWithFolder:folder documentFileName:[self.slug stringByAppendingPathExtension:@"jpg"]];
+}
+
 - (NSString *)thumbnailFilePath
 {
     NSString *slug = [Partner currentPartnerID];

--- a/Classes/Operations/ARPDFThumbnailCreationOperation.m
+++ b/Classes/Operations/ARPDFThumbnailCreationOperation.m
@@ -83,6 +83,7 @@ float LegacyImageSize = 230;
 
         ARSyncLog(@"An exception was raised in rendering the PDF thumbnail for %@. \n %@", _source, exception);
         [self cancelRendering];
+        CFRelease(pdfDocument);
         return;
     }
 
@@ -91,6 +92,7 @@ float LegacyImageSize = 230;
 
     CGContextRestoreGState(context);
     UIGraphicsEndImageContext();
+    CFRelease(pdfDocument);
 
     NSError *error = nil;
     [[NSFileManager defaultManager] createDirectoryAtPath:[_destination stringByDeletingLastPathComponent] withIntermediateDirectories:YES attributes:nil error:&error];

--- a/Classes/Operations/ARThumbnailCreationOperation.m
+++ b/Classes/Operations/ARThumbnailCreationOperation.m
@@ -46,7 +46,7 @@ float SmallImageViewSize = 115;
 {
     if (self = [super init]) {
         _source = document.filePath;
-        _destination = document.thumbnailFilePath;
+        _destination = document.newThumbnailFilePath;
     }
     return self;
 }

--- a/Classes/Operations/ARThumbnailCreationOperation.m
+++ b/Classes/Operations/ARThumbnailCreationOperation.m
@@ -46,7 +46,7 @@ float SmallImageViewSize = 115;
 {
     if (self = [super init]) {
         _source = document.filePath;
-        _destination = document.newThumbnailFilePath;
+        _destination = document.customThumbnailFilePath;
     }
     return self;
 }

--- a/Classes/Sync/Documents/ARDocumentThumbnailCreator.m
+++ b/Classes/Sync/Documents/ARDocumentThumbnailCreator.m
@@ -17,7 +17,7 @@
 {
     NSOperation *operation = nil;
     if ([document.filename hasSuffix:@"pdf"]) {
-        operation = [ARPDFThumbnailCreationOperation operationWithPDFSourcePath:document.filePath andDestinationPath:document.newThumbnailFilePath];
+        operation = [ARPDFThumbnailCreationOperation operationWithPDFSourcePath:document.filePath andDestinationPath:document.customThumbnailFilePath];
     } else {
         operation = [ARThumbnailCreationOperation operationWithDocument:document];
     }

--- a/Classes/Sync/Documents/ARDocumentThumbnailCreator.m
+++ b/Classes/Sync/Documents/ARDocumentThumbnailCreator.m
@@ -17,7 +17,7 @@
 {
     NSOperation *operation = nil;
     if ([document.filename hasSuffix:@"pdf"]) {
-        operation = [ARPDFThumbnailCreationOperation operationWithPDFSourcePath:document.filePath andDestinationPath:document.thumbnailFilePath];
+        operation = [ARPDFThumbnailCreationOperation operationWithPDFSourcePath:document.filePath andDestinationPath:document.newThumbnailFilePath];
     } else {
         operation = [ARThumbnailCreationOperation operationWithDocument:document];
     }


### PR DESCRIPTION
- [x] Diagnosis & fix 
- [ ] Design that makes the most sense
- [ ] Tests 

The document thumbnail creator was checking for fileExists before it should have been, so it wasn't able to properly store thumbnails where they were supposed to be. I'm thinking it would make sense to have a method that creates a new thumbnail filepath and a different method for accessing an existing filepath (which should also return the generic one if the thumbnail doesn't exist).

Thoughts?

![simulator screen shot oct 13 2015 5 15 49 pm](https://cloud.githubusercontent.com/assets/2712962/10468796/2e3d7c22-71cf-11e5-8364-86a48fd77374.png)
