### PR TITLE
@sarahscott => Use new env var to indicate you're artsy staff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ LOCAL_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 BRANCH = $(shell echo $(shell whoami)-$(shell git rev-parse --abbrev-ref HEAD))
 
 pr:
-	if [ "$(LOCAL_BRANCH)" == "master" ]; then echo "In master, not PRing"; else git push origin "$(LOCAL_BRANCH):$(BRANCH)"; open -a "Google Chrome" "https://github.com/artsy/energy/pull/new/artsy:master...$(BRANCH)"; fi
+	if [ "$(LOCAL_BRANCH)" == "master" ]; then echo "In master, not PRing"; else git push origin "$(LOCAL_BRANCH):$(BRANCH)"; open "https://github.com/artsy/energy/pull/new/artsy:master...$(BRANCH)"; fi
 
 push:
 	if [ "$(LOCAL_BRANCH)" == "master" ]; then echo "In master, not pushing"; else git push origin $(LOCAL_BRANCH):$(BRANCH); fi

--- a/Podfile
+++ b/Podfile
@@ -28,7 +28,7 @@ target 'ArtsyFolio' do
     pod 'UIView+BooleanAnimations'
     pod 'ORStackView'
 
-    if %w(orta ash artsy laura eloy sarahscott).include?(ENV['USER']) || ENV['CI'] == 'true'
+    if ENV['ARTSY_STAFF_MEMBER'] || ENV['CI'] == 'true'
         pod 'Artsy+UIFonts', :git => "https://github.com/artsy/Artsy-UIFonts.git", :branch => "old_fonts_new_lib"
     else
       pod 'Artsy+OSSUIFonts'

--- a/docs/CHANGELOG.yml
+++ b/docs/CHANGELOG.yml
@@ -1,13 +1,19 @@
 upcoming:
-  version: 2.4.4
+  version: 2.5.0
   notes:
     - Lab Settings Master View [sarah]
-    - Switch back to static libraries to speed up launch time [orta]
-    - Minor changes to how the popovers handles resizing [orta]
-    - Saved memory in PDF rendering for iOS 9 [sarah]
-    - Intercom fix [orta]
+    - Podfile uses `ARTSY_STAFF_MEMBER` to use closed source fonts [orta]
+
 
 releases:
+  - version: 2.4.4
+    date: Oct 20 2015
+    notes:
+      - Switch back to static libraries to speed up launch time [orta]
+      - Minor changes to how the popovers handles resizing [orta]
+      - Saved memory in PDF rendering for iOS 9 [sarah]
+      - Intercom fix [orta]
+
   - version: 2.4.3
     date: Oct 6 2015
     notes:


### PR DESCRIPTION
You'll need to set this, as I'm going to make all Artsy projects do it this way. Removes Google Chrome from `make pr` - I had stopped using GitHub GIFs.