### PR TITLE
@sarahscott => Move to artsy authentication, and improve login error messages

### DIFF
--- a/ArtsyFolio Tests/View Controllers/ARLoginViewControllerTests.m
+++ b/ArtsyFolio Tests/View Controllers/ARLoginViewControllerTests.m
@@ -22,7 +22,7 @@
 
 - (void)presentPartnerSelectionToolWithJSON:(NSArray *)JSON;
 - (void)presentAdminPartnerSelectionTool;
-- (void)loginCompleted:(NSNotification *)notification;
+- (void)loginCompleted;
 @end
 
 SpecBegin(ARLoginViewController);
@@ -43,19 +43,6 @@ it(@"look right on ipad", ^{
     }];
 });
 
-// This cannot be tested in Xcode 6, but it works when being ran on an iOS7 devide
-// when migrating to iOS8 only this can be changed
-
-pending(@"hides the ad on landscape orientation", ^{
-    [ARTestContext useContext:ARTestContextDeviceTypePad :^{
-        before();
-
-        BOOL should = [controller shouldAutorotateToInterfaceOrientation:UIInterfaceOrientationLandscapeLeft];
-        expect(should).to.beTruthy();
-        expect(controller.appRecommendationView.hidden).to.beTruthy();
-    }];
-});
-
 it(@"look right on phone", ^{
     [ARTestContext useContext:ARTestContextDeviceTypePhone4 :^{
         before();
@@ -69,7 +56,7 @@ it(@"presents partner selection tool for users with multiple partners", ^{
 
     id controllerMock = [OCMockObject partialMockForObject:controller];
     [[controllerMock expect] presentPartnerSelectionToolWithJSON:[OCMArg any]];
-    [controller loginCompleted:nil];
+    [controller loginCompleted];
     [controllerMock verify];
 });
 
@@ -79,7 +66,7 @@ it(@"presents admin tool when user is an admin", ^{
 
     id controllerMock = [OCMockObject partialMockForObject:controller];
     [[controllerMock expect] presentAdminPartnerSelectionTool];
-    [controller loginCompleted:nil];
+    [controller loginCompleted];
     [controllerMock verify];
 });
 
@@ -87,7 +74,7 @@ it(@"correctly parses in a partner", ^{
     before();
     controller.networkModel = [[ARStubbedLoginNetworkModel alloc] initWithPartnerCount:ARLoginPartnerCountOne isAdmin:NO];
 
-    [controller loginCompleted:nil];
+    [controller loginCompleted];
 
     expect([[Partner currentPartnerInContext:controller.managedObjectContext] name]).to.equal(@"Test Partner");
 });

--- a/ArtsyFolio Tests/View Controllers/ARStubbedLoginNetworkModel.h
+++ b/ArtsyFolio Tests/View Controllers/ARStubbedLoginNetworkModel.h
@@ -7,12 +7,10 @@
 @property (nonatomic, assign) BOOL isAdmin;
 @property (nonatomic, assign) ARLoginPartnerCount stubbedPartnerCount;
 
+@property (nonatomic, copy) NSDictionary *loginErrorDict;
+@property (nonatomic, assign) BOOL isArtsyUp;
+@property (nonatomic, assign) BOOL isAppleUp;
+
 - (instancetype)initWithPartnerCount:(ARLoginPartnerCount)count isAdmin:(BOOL)admin;
-
-- (void)getUserInformation:(void (^)(id userInfo))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure;
-
-- (void)getCurrentUserPartnersWithSuccess:(void (^)(id partners, ARLoginPartnerCount partnerCount))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure;
-
-- (void)getFullMetadataForPartnerWithID:(NSString *)partnerID success:(void (^)(id partnerDictionary))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure;
 
 @end

--- a/ArtsyFolio Tests/View Controllers/ARStubbedLoginNetworkModel.m
+++ b/ArtsyFolio Tests/View Controllers/ARStubbedLoginNetworkModel.m
@@ -69,4 +69,23 @@
     success(partnerMetadata);
 }
 
+- (void)pingArtsy:(void (^)(void))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))artsyFailure;
+{
+    if (self.isArtsyUp) {
+        success();
+    } else {
+        artsyFailure(nil, nil, nil, nil);
+    }
+}
+
+- (void)pingApple:(void (^)(void))success failure:(void (^)(NSURLRequest *, NSHTTPURLResponse *, NSError *))appleFailure
+{
+    if (self.isAppleUp) {
+        success();
+    } else {
+        appleFailure(nil, nil, nil);
+    }
+}
+
+
 @end

--- a/Classes/ARAppDelegate.m
+++ b/Classes/ARAppDelegate.m
@@ -27,6 +27,7 @@ void uncaughtExceptionHandler(NSException *exception);
 @property (nonatomic, strong, readonly) ARInitialViewControllerSetupCoordinator *viewCoordinator;
 @property (nonatomic, strong, readonly) ARAnalyticsHelper *analyticsHelper;
 @property (nonatomic, strong, readonly) AROfflineStatusWatcher *statusWatcher;
+@property (nonatomic, strong, readonly) ARUserManager *userManager;
 
 // Needed for testing.
 @property (nonatomic, strong) id defaultsClassMock;
@@ -88,13 +89,14 @@ void uncaughtExceptionHandler(NSException *exception);
     _partnerSync = [[ARPartnerMetadataSync alloc] init];
     _statusWatcher = [[AROfflineStatusWatcher alloc] initWithSync:self.sync];
     _viewCoordinator = [[ARInitialViewControllerSetupCoordinator alloc] initWithWindow:self.window sync:self.sync];
+    _userManager = [[ARUserManager alloc] init];
 
     [self.viewCoordinator setupFolioGrid];
 
     BOOL useWhiteFolio = [defaults boolForKey:AROptionsUseWhiteFolio];
-    BOOL hasLoggedInSyncedUser = [ARUserManager loginCredentialsExist] && [Partner currentPartner];
+    BOOL hasLoggedInSyncedUser = self.userManager.userCredentialsExist && [Partner currentPartner];
     BOOL hasLoggedInUnsyncedUser = [defaults boolForKey:ARStartedFirstSync] && ![defaults boolForKey:ARFinishedFirstSync];
-    BOOL loggedIn = [ARUserManager userIsLoggedIn];
+    BOOL loggedIn = self.userManager.userIsLoggedIn;
     BOOL shouldLockOut = [defaults boolForKey:ARLimitedAccess];
 
     [ARTheme setupWithWhiteFolio:useWhiteFolio];
@@ -171,7 +173,7 @@ void uncaughtExceptionHandler(NSException *exception);
 {
     // let them through into the app whilst it re-auths in the background.
     [ARAnalytics event:@"Updating auth token"];
-    [ARUserManager requestLoginWithStoredCredentials];
+    [self.userManager requestLoginWithStoredCredentials];
 }
 
 #pragma mark -

--- a/Classes/Constants/ARNetworkConstants.h
+++ b/Classes/Constants/ARNetworkConstants.h
@@ -4,7 +4,9 @@ extern NSString *const ARAuthHeader;
 
 extern NSString *const ARBaseURL;
 extern NSString *const ARStaticBaseURL;
-extern NSString *const AROAuthURL;
+
+extern NSString *const ARSiteUpURL;
+
 extern NSString *const ARArtworkURLFormat;
 extern NSString *const ARMyInfoURL;
 extern NSString *const ARMyPartnersURL;

--- a/Classes/Constants/ARNetworkConstants.m
+++ b/Classes/Constants/ARNetworkConstants.m
@@ -4,9 +4,10 @@ NSString *const ARBaseURL = @"https://api.artsy.net";
 
 NSString *const ARStaticBaseURL = @"http://static.artsy.net";
 
-NSString *const AROAuthURL = @"/oauth2/access_token";
-NSString *const ARArtworkURLFormat = @"/api/v1/artwork/%@";
+NSString *const ARSiteUpURL = @"/api/v1/system/up";
 
+
+NSString *const ARArtworkURLFormat = @"/api/v1/artwork/%@";
 NSString *const ARMyPartnersURL = @"/api/v1/me/partners";
 NSString *const ARSearchPartnersURL = @"/api/v1/match/partners";
 

--- a/Classes/Constants/ARNotifications.h
+++ b/Classes/Constants/ARNotifications.h
@@ -5,10 +5,6 @@ extern NSString *const ARAllArtworksDownloadedNotification;
 extern NSString *const ARSyncStartedNotification;
 extern NSString *const ARSyncFinishedNotification;
 
-extern NSString *const ARLoginCompleteNotification;
-extern NSString *const ARLoginFailedNotification;
-extern NSString *const ARLoginFailedServerNotification;
-
 extern NSString *const ARArtworkEnsureShowingMetadataNotification;
 extern NSString *const ARToggleArtworkInfoNotification;
 extern NSString *const ARShowArtworkInfoNotification;

--- a/Classes/Constants/ARNotifications.m
+++ b/Classes/Constants/ARNotifications.m
@@ -1,9 +1,5 @@
 // Notification names
 
-NSString *const ARLoginCompleteNotification = @"ARLoginCompleteNotification";
-NSString *const ARLoginFailedNotification = @"ARLoginFailedNotification";
-NSString *const ARLoginFailedServerNotification = @"ARLoginFailedServerNotification";
-
 // New Sync notifications
 NSString *const ARLargeImageDownloadCompleteNotification = @"ARLargeImageDownloadCompleteNotification";
 NSString *const ARAllArtworksDownloadedNotification = @"ARAllArtworksDownloadedNotification";

--- a/Classes/Controllers/Login & Setup/Login/ARLoginNetworkModel.h
+++ b/Classes/Controllers/Login & Setup/Login/ARLoginNetworkModel.h
@@ -7,10 +7,19 @@ typedef NS_ENUM(NSInteger, ARLoginPartnerCount) {
 
 @interface ARLoginNetworkModel : NSObject
 
+/// Get the user info
 - (void)getUserInformation:(void (^)(id userInfo))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure;
 
+/// Get all Partners associated with the user
 - (void)getCurrentUserPartnersWithSuccess:(void (^)(id partners, ARLoginPartnerCount partnerCount))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure;
 
+/// Get Full Partner Metadata
 - (void)getFullMetadataForPartnerWithID:(NSString *)partnerID success:(void (^)(id partnerDictionary))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure;
+
+/// Is Artsy up?
+- (void)pingArtsy:(void (^)(void))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure;
+
+/// Is Apple up? A pretty reliable way to check if the user is offline
+- (void)pingApple:(void (^)(void))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
 
 @end

--- a/Classes/Controllers/Login & Setup/Login/ARLoginNetworkModel.m
+++ b/Classes/Controllers/Login & Setup/Login/ARLoginNetworkModel.m
@@ -57,4 +57,33 @@
 }
 
 
+- (void)pingArtsy:(void (^)(void))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure
+{
+    NSURLRequest *request = [ARRouter newArtsyPing];
+
+    AFJSONRequestOperation *operation = [AFJSONRequestOperation JSONRequestOperationWithRequest:request success:^(NSURLRequest *request, NSHTTPURLResponse *response, id JSON) {
+        success();
+
+    } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
+        if (failure) failure(request, response, error, JSON);
+    }];
+
+    [operation start];
+}
+
+- (void)pingApple:(void (^)(void))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure
+{
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.apple.com/"] cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:60.0];
+
+    AFHTTPRequestOperation *operation = [[AFHTTPRequestOperation alloc] initWithRequest:request];
+    [operation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
+        success();
+    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        failure(operation.request, operation.response, error);
+    }];
+
+    [operation start];
+}
+
+
 @end

--- a/Classes/Controllers/Login & Setup/Login/ARLoginViewController.h
+++ b/Classes/Controllers/Login & Setup/Login/ARLoginViewController.h
@@ -18,4 +18,6 @@
 @property (nonatomic, strong) IBOutlet ARTextFieldWithPlaceholder *emailTextField;
 @property (nonatomic, strong) IBOutlet ARTextFieldWithPlaceholder *passwordTextField;
 
+@property (nonatomic, weak) IBOutlet UILabel *errorMessageLabel;
+
 @end

--- a/Classes/Controllers/Login & Setup/Login/ARLoginViewController.m
+++ b/Classes/Controllers/Login & Setup/Login/ARLoginViewController.m
@@ -23,7 +23,6 @@
 @property (nonatomic, weak) IBOutlet UILabel *emailLabel;
 @property (nonatomic, weak) IBOutlet UILabel *passwordLabel;
 @property (nonatomic, weak) IBOutlet UILabel *welcomeMessageLabel;
-@property (nonatomic, weak) IBOutlet UILabel *errorMessageLabel;
 @property (nonatomic, weak) IBOutlet UIButton *clearEmailButton;
 @property (nonatomic, weak) IBOutlet UIButton *clearPasswordButton;
 @property (nonatomic, weak) IBOutlet UILabel *iphoneSubheadingLabel;
@@ -254,7 +253,7 @@
 
         } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
             /// OK, they are definitely offline.
-            [self resetWithErrorMessage:@"Folio is having trouble connecting to Artsy, and the App Store, you may be having WIFI or networking issues."];
+            [self resetWithErrorMessage:@"Folio is having trouble connecting to Artsy, and the internet in general, you may be having WIFI or networking issues."];
         }];
     }];
 }

--- a/Classes/Controllers/Login & Setup/Login/ARLoginViewController.m
+++ b/Classes/Controllers/Login & Setup/Login/ARLoginViewController.m
@@ -233,7 +233,6 @@
 
     [self.networkModel pingArtsy:^{
         // Artsy is up
-        NSLog(@"Artsy is up");
         NSString *serverError = error.userInfo[@"error_description"];
 
         /// Let's have a less robotic error message for the most

--- a/Classes/Util/App/ARRouter.h
+++ b/Classes/Util/App/ARRouter.h
@@ -13,9 +13,10 @@
 
 + (NSURLRequest *)requestForURL:(NSURL *)url;
 
-/// User info
-+ (NSURLRequest *)newOAuthRequestWithUsername:(NSString *)username password:(NSString *)password;
+/// Misc site
++ (NSURLRequest *)newArtsyPing;
 
+/// User info
 + (NSURLRequest *)newUserInfoRequest;
 
 /// Partner info

--- a/Classes/Util/App/ARRouter.m
+++ b/Classes/Util/App/ARRouter.m
@@ -57,18 +57,9 @@ static NSURL *staticBaseURL = nil;
     [httpClient setDefaultHeader:ARAuthHeader value:token];
 }
 
-+ (NSURLRequest *)newOAuthRequestWithUsername:(NSString *)username password:(NSString *)password
++ (NSURLRequest *)newArtsyPing
 {
-    FolioKeys *keys = [[FolioKeys alloc] init];
-    NSDictionary *params = @{
-        @"email" : username,
-        @"password" : password,
-        @"client_id" : [keys artsyAPIClientKey],
-        @"client_secret" : [keys artsyAPIClientSecret],
-        @"grant_type" : @"credentials",
-        @"scope" : @"offline_access"
-    };
-    return [httpClient requestWithMethod:@"GET" path:AROAuthURL parameters:params];
+    return [httpClient requestWithMethod:@"GET" path:ARSiteUpURL parameters:nil];
 }
 
 #pragma mark -

--- a/Classes/Util/App/ARUserManager.h
+++ b/Classes/Util/App/ARUserManager.h
@@ -1,14 +1,21 @@
 #import <Foundation/Foundation.h>
 
+/// Handles interacting with user state
+/// and logging in.
+
 
 @interface ARUserManager : NSObject
-+ (BOOL)userIsLoggedIn;
 
-+ (void)expireAuthToken;
+/// User is logged in and token is still valid
+- (BOOL)userIsLoggedIn;
 
-+ (BOOL)loginCredentialsExist;
+/// User has credentials in the defaults
+/// but we don't know if they're logged in
+- (BOOL)userCredentialsExist;
 
-+ (void)requestLoginWithStoredCredentials;
+/// Uses the stored credentials to log in transparently
+- (void)requestLoginWithStoredCredentials;
 
-+ (void)requestLoginWithUsername:(NSString *)username andPassword:(NSString *)password;
+/// Logs in with the username / password
+- (void)requestLoginWithUsername:(NSString *)username andPassword:(NSString *)password completion:(void (^)(BOOL success, NSError *error))completion;
 @end

--- a/Podfile
+++ b/Podfile
@@ -27,6 +27,7 @@ target 'ArtsyFolio' do
     pod 'Artsy+UIColors'
     pod 'UIView+BooleanAnimations'
     pod 'ORStackView'
+    pod "Artsy+Authentication", :subspecs => ["EmailOnly"], :git => "https://github.com/artsy/Artsy-Authentication", :branch => "make_a_release"
 
     if ENV['ARTSY_STAFF_MEMBER'] || ENV['CI'] == 'true'
         pod 'Artsy+UIFonts', :git => "https://github.com/artsy/Artsy-UIFonts.git", :branch => "old_fonts_new_lib"

--- a/Podfile
+++ b/Podfile
@@ -27,7 +27,7 @@ target 'ArtsyFolio' do
     pod 'Artsy+UIColors'
     pod 'UIView+BooleanAnimations'
     pod 'ORStackView'
-    pod "Artsy+Authentication", :subspecs => ["EmailOnly"], :git => "https://github.com/artsy/Artsy-Authentication", :branch => "make_a_release"
+    pod "Artsy+Authentication", :subspecs => ["email"]
 
     if ENV['ARTSY_STAFF_MEMBER'] || ENV['CI'] == 'true'
         pod 'Artsy+UIFonts', :git => "https://github.com/artsy/Artsy-UIFonts.git", :branch => "old_fonts_new_lib"

--- a/Podfile
+++ b/Podfile
@@ -88,7 +88,7 @@ target 'ArtsyFolio Tests' do
 
     pod 'XCTest+OHHTTPStubSuiteCleanUp'
     pod 'OCMock'
-    pod 'Forgeries/Mocks'
+    pod 'Forgeries/Mocks', :git => "https://github.com/ashfurrow/Forgeries.git", :branch => "remove"
 end
 
 post_install do |installer|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,9 +15,9 @@ PODS:
   - ARGenericTableViewController (1.0.2)
   - ARTiledImageView (1.2):
     - SDWebImage/Core
-  - Artsy+Authentication/EmailOnly (1.5.0):
-    - ISO8601DateFormatter (> 0)
-    - NSURL+QueryDictionary (> 0)
+  - Artsy+Authentication/email (1.5.0):
+    - ISO8601DateFormatter
+    - NSURL+QueryDictionary
   - Artsy+UIColors (1.0.0):
     - EDColor (~> 0.4)
   - Artsy+UIFonts (1.1.0)
@@ -87,8 +87,7 @@ DEPENDENCIES:
   - ARCollectionViewMasonryLayout
   - ARGenericTableViewController (from `https://github.com/orta/ARGenericTableViewController.git`)
   - ARTiledImageView (from `https://github.com/dblock/ARTiledImageView.git`)
-  - Artsy+Authentication/EmailOnly (from `https://github.com/artsy/Artsy-Authentication`,
-    branch `make_a_release`)
+  - Artsy+Authentication/email
   - Artsy+UIColors
   - Artsy+UIFonts (from `https://github.com/artsy/Artsy-UIFonts.git`, branch `old_fonts_new_lib`)
   - Artsy+UILabels
@@ -134,9 +133,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/orta/ARGenericTableViewController.git
   ARTiledImageView:
     :git: https://github.com/dblock/ARTiledImageView.git
-  Artsy+Authentication:
-    :branch: make_a_release
-    :git: https://github.com/artsy/Artsy-Authentication
   Artsy+UIFonts:
     :branch: old_fonts_new_lib
     :git: https://github.com/artsy/Artsy-UIFonts.git
@@ -163,9 +159,6 @@ CHECKOUT OPTIONS:
   ARTiledImageView:
     :commit: f85a14e750231d23ecb971694f72ad1473777ec0
     :git: https://github.com/dblock/ARTiledImageView.git
-  Artsy+Authentication:
-    :commit: 2d1a840468463f3e9d645327d9bfc587b3b83b82
-    :git: https://github.com/artsy/Artsy-Authentication
   Artsy+UIFonts:
     :commit: 39f47deebf947aa4c07727fdf2b69e2feff17428
     :git: https://github.com/artsy/Artsy-UIFonts.git
@@ -186,7 +179,7 @@ SPEC CHECKSUMS:
   ARCollectionViewMasonryLayout: 164b82010cf8ec99bc7a38cffe59a179d7e5a116
   ARGenericTableViewController: 61a0897ba66c35111b5d1cc3b44884282bd3c1a5
   ARTiledImageView: 000af4093f9bdcd0f754e6ebd964c90641389f90
-  Artsy+Authentication: 11b4831d17ef9ba8be86debeff09ae6766d0e6ce
+  Artsy+Authentication: 8ecf6729902827c49c9bc54155ac9495929fcbcb
   Artsy+UIColors: 7a4c987885a8d8da3e22672a3232761f929dd2b6
   Artsy+UIFonts: 108bfe625c45008ebb15c4c62003882dd345c4b8
   Artsy+UILabels: 43da757ee01bce8165ec83123eccccdf1fe8843c

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,6 +15,9 @@ PODS:
   - ARGenericTableViewController (1.0.2)
   - ARTiledImageView (1.2):
     - SDWebImage/Core
+  - Artsy+Authentication/EmailOnly (1.5.0):
+    - ISO8601DateFormatter (> 0)
+    - NSURL+QueryDictionary (> 0)
   - Artsy+UIColors (1.0.0):
     - EDColor (~> 0.4)
   - Artsy+UIFonts (1.1.0)
@@ -56,6 +59,7 @@ PODS:
   - libextobjc/EXTScope (0.4.1):
     - libextobjc/RuntimeExtensions
   - libextobjc/RuntimeExtensions (0.4.1)
+  - NSURL+QueryDictionary (1.1.0)
   - ObjectiveSugar (1.1.1)
   - OCMock (3.1.5)
   - OHHTTPStubs (3.1.6):
@@ -83,6 +87,8 @@ DEPENDENCIES:
   - ARCollectionViewMasonryLayout
   - ARGenericTableViewController (from `https://github.com/orta/ARGenericTableViewController.git`)
   - ARTiledImageView (from `https://github.com/dblock/ARTiledImageView.git`)
+  - Artsy+Authentication/EmailOnly (from `https://github.com/artsy/Artsy-Authentication`,
+    branch `make_a_release`)
   - Artsy+UIColors
   - Artsy+UIFonts (from `https://github.com/artsy/Artsy-UIFonts.git`, branch `old_fonts_new_lib`)
   - Artsy+UILabels
@@ -128,6 +134,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/orta/ARGenericTableViewController.git
   ARTiledImageView:
     :git: https://github.com/dblock/ARTiledImageView.git
+  Artsy+Authentication:
+    :branch: make_a_release
+    :git: https://github.com/artsy/Artsy-Authentication
   Artsy+UIFonts:
     :branch: old_fonts_new_lib
     :git: https://github.com/artsy/Artsy-UIFonts.git
@@ -154,6 +163,9 @@ CHECKOUT OPTIONS:
   ARTiledImageView:
     :commit: f85a14e750231d23ecb971694f72ad1473777ec0
     :git: https://github.com/dblock/ARTiledImageView.git
+  Artsy+Authentication:
+    :commit: 2d1a840468463f3e9d645327d9bfc587b3b83b82
+    :git: https://github.com/artsy/Artsy-Authentication
   Artsy+UIFonts:
     :commit: 39f47deebf947aa4c07727fdf2b69e2feff17428
     :git: https://github.com/artsy/Artsy-UIFonts.git
@@ -174,6 +186,7 @@ SPEC CHECKSUMS:
   ARCollectionViewMasonryLayout: 164b82010cf8ec99bc7a38cffe59a179d7e5a116
   ARGenericTableViewController: 61a0897ba66c35111b5d1cc3b44884282bd3c1a5
   ARTiledImageView: 000af4093f9bdcd0f754e6ebd964c90641389f90
+  Artsy+Authentication: 11b4831d17ef9ba8be86debeff09ae6766d0e6ce
   Artsy+UIColors: 7a4c987885a8d8da3e22672a3232761f929dd2b6
   Artsy+UIFonts: 108bfe625c45008ebb15c4c62003882dd345c4b8
   Artsy+UILabels: 43da757ee01bce8165ec83123eccccdf1fe8843c
@@ -197,6 +210,7 @@ SPEC CHECKSUMS:
   Keys: 7d2ff6ff42f6903358267ce56e9392f83c31acfe
   KVOController: 9fd8f0343670994e4b6f9f0b31f5a45663f3e1cf
   libextobjc: a650fc1bf489a3d3a9bc2e621efa3e1006fc5471
+  NSURL+QueryDictionary: dd0a5fec689a9b4780b6fa0e0225c01ca3ea653e
   ObjectiveSugar: 0729eb74a757ea48b109a8902178c9b89aa58a9f
   OCMock: 4c2925291f80407c3738dd1db14d21d0cc278864
   OHHTTPStubs: b671969016b4c6f5ee3c26080c81114ba82e0710

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -98,7 +98,7 @@ DEPENDENCIES:
   - Expecta+ContainerClasses (~> 1.0)
   - Expecta+Snapshots (= 2.0.0)
   - FLKAutoLayout (= 0.1.1)
-  - Forgeries/Mocks
+  - Forgeries/Mocks (from `https://github.com/ashfurrow/Forgeries.git`, branch `remove`)
   - GHMarkdownParser
   - GRMustache (~> 7.0)
   - Intercom
@@ -136,6 +136,9 @@ EXTERNAL SOURCES:
   Artsy+UIFonts:
     :branch: old_fonts_new_lib
     :git: https://github.com/artsy/Artsy-UIFonts.git
+  Forgeries:
+    :branch: remove
+    :git: https://github.com/ashfurrow/Forgeries.git
   Keys:
     :path: Pods/CocoaPodsKeys/
   ObjectiveSugar:
@@ -162,6 +165,9 @@ CHECKOUT OPTIONS:
   Artsy+UIFonts:
     :commit: 39f47deebf947aa4c07727fdf2b69e2feff17428
     :git: https://github.com/artsy/Artsy-UIFonts.git
+  Forgeries:
+    :commit: b763101eb029fd60df1b22c795514a8caf1d7dbb
+    :git: https://github.com/ashfurrow/Forgeries.git
   ObjectiveSugar:
     :commit: 14ac406bd0dbb7fd96c72924f9e7196608f456a4
     :git: https://github.com/supermarin/ObjectiveSugar.git

--- a/docs/CHANGELOG.yml
+++ b/docs/CHANGELOG.yml
@@ -1,6 +1,7 @@
 upcoming:
   version: 2.5.0
   notes:
+    - Improved Error Messages for Login [orta]
     - [dev] Edit Presentation Mode Settings view controller [sarah]
     - [dev] Introduced Presentation Mode [sarah]
     - [dev] New sync settings view controller [sarah]


### PR DESCRIPTION
- [x] Rough structure
- [x] Second Look
- [x] Tests

* I've moved our authentication networking to work via [Artsy_Authentication](https://github.com/artsy/Artsy-Authentication). Which makes 3/4 apps now.
* I've de-singleton'd the ARUserManager
* I've improved our error messaging. The flow is different now.
  -  We try log them in, if it succeeds, continue.
  -  Otherwise, try ping a known artsy route for checking if artsy is up
    - if that passes then the error message is likely legit.
    - if that fails, check if apple.com is up.
      - if that passes then Artsy is down
      - if that fails then the user is offline

Previously if there were any network issues, then it is assumed that Artsy is down, which was pretty true when I wrote the app login 4 years ago, but not true anymore.   