### PR TITLE
Took out ci_keys as there is no rule to make that target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ oss:
 	bundle -v >/dev/null 2>&1 || { echo "Energy requires bundler, but it's not installed.  You can install it via '[sudo] gem install bundler'. If you are new to ruby, we *strongly* recommend using a sudo-less installation: https://guides.cocoapods.org/using/getting-started.html#sudo-less-installation" >&2; exit 1; }
 	xcode-select -p >/dev/null 2>&1 || { echo "Energy requires that Apple's command line Xcode tools are installed.  You can install them by running: 'xcode-select --install'. " >&2; exit 1; }
 	bundle install
-	$(MAKE) ci_keys
 	find . -type f -name 'ArtsyPartner-Prefix.pch' -exec sed -i '' 's/ARIsOSSBuild = NO;/ARIsOSSBuild = YES;/g'  {} +
 	bundle exec pod install
 


### PR DESCRIPTION
@sarahscott @orta 

`make oss` wasn't working, as there was no rule to make the ci_keys target. Took it out, seemed to all work fine? It now preps, pod installs, and you get your workspace just fine :). 

To get it to build, there's still a thing with fonts, but that will be PR 2 from me ^_^. 

Also - do I PR this onto master? Are there any rules around this?
