### PR TITLE
Use public XCTest macro instead of "private" one

### DIFF
--- a/ArtsyFolio Tests/Testing Util Objects/AROHHTTPNoStubAssertionBot.m
+++ b/ArtsyFolio Tests/Testing Util Objects/AROHHTTPNoStubAssertionBot.m
@@ -61,7 +61,7 @@
         printf("   Stack trace: %s\n\n\n\n", [stackTrace componentsJoinedByString:@"\n                "].UTF8String);
     }
 
-    _XCTPrimitiveFail(spectaExample, @"Failed due to unstubbed networking.");
+    XCTFail(spectaExample, @"Failed due to unstubbed networking.");
     return nil;
 }
 


### PR DESCRIPTION
Namely, `XCFail` over `_XCTPrimitiveFail`.