### PR TITLE
[WIP] Fix of Partner data model to match Gravity's JSON 

### DIFF
--- a/Artsy Folio.xcodeproj/project.pbxproj
+++ b/Artsy Folio.xcodeproj/project.pbxproj
@@ -1360,6 +1360,7 @@
 		60FDF6DC1AEAA21800173E81 /* ARSearchViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARSearchViewControllerTests.m; sourceTree = "<group>"; };
 		60FFE3B8156FAE5000A138D3 /* RecentlyUploadedPlaceholder.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = RecentlyUploadedPlaceholder.jpg; sourceTree = "<group>"; };
 		60FFE3B9156FAE5000A138D3 /* RecentlyUploadedPlaceholder@2x.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "RecentlyUploadedPlaceholder@2x.jpg"; sourceTree = "<group>"; };
+		6668EC321C6E3D390064D420 /* ArtsyFolio v2.5.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "ArtsyFolio v2.5.xcdatamodel"; sourceTree = "<group>"; };
 		6EB736AE98DB5666E010A0CE /* libPods-ArtsyFolio.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ArtsyFolio.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8305D67E1AE05168004A270E /* ARThumbnailImageScrollView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARThumbnailImageScrollView.h; sourceTree = "<group>"; };
 		8305D67F1AE05168004A270E /* ARThumbnailImageScrollView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARThumbnailImageScrollView.m; sourceTree = "<group>"; };
@@ -4673,6 +4674,7 @@
 		60118682174D084700B878A1 /* ArtsyPartner.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				6668EC321C6E3D390064D420 /* ArtsyFolio v2.5.xcdatamodel */,
 				839B59751B4D955900F24033 /* ArtsyFolio v2.4.xcdatamodel */,
 				8343B7BC1B4C5667005790A9 /* ArtsyFolio v2.3.xcdatamodel */,
 				60D210D61AE04A4400EA091C /* ArtsyFolio v2.2.xcdatamodel */,
@@ -4687,7 +4689,7 @@
 				60118687174D084700B878A1 /* ArtsyPartner 5.xcdatamodel */,
 				60118688174D084700B878A1 /* ArtsyPartner.xcdatamodel */,
 			);
-			currentVersion = 839B59751B4D955900F24033 /* ArtsyFolio v2.4.xcdatamodel */;
+			currentVersion = 6668EC321C6E3D390064D420 /* ArtsyFolio v2.5.xcdatamodel */;
 			path = ArtsyPartner.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/ArtsyFolio Tests/Models/PartnerModelTests.m
+++ b/ArtsyFolio Tests/Models/PartnerModelTests.m
@@ -7,7 +7,28 @@ __block Partner *partner;
 
 beforeEach(^{
     context = [CoreDataManager stubbedManagedObjectContext];
-    partner = [Partner objectInContext:context];
+    partner = [Partner modelFromJSON:@{ ARFeedNameKey : @"Folio",
+                                        ARFeedWebsiteKey : @"http://www.artsy.net",
+                                        ARFeedEmailKey : @"test@artsy.net",
+                                        ARFeedTypeKey : @"Gallery",
+                                        ARFeedArtworksCountKey : @27,
+                                        ARFeedArtistDocumentsCountKey : @3,
+                                        ARFeedArtistsCountKey : @4,
+                                        ARFeedPartnerSubscriptionStateKey : @"active",
+                                        ARFeedRegionKey : @"Europe",
+                                        ARFeedHasLimitedPartnerToolAccessKey : @NO,
+                                        ARFeedRelativeSizeKey : @1,
+                                        ARFeedPartnerContractTypeKey : @"subscription",
+                                        ARFeedHasFullProfileKey : @NO,
+                                        ARFeedHasDefaultProfileIDKey : @"some_string",
+                                        ARFeedDefaultProfilePublicKey : @NO,
+                                        ARFeedPartnerRawIDKey : @"1234",
+                                        ARFeedPartnerIsFoundingPartnerKey : @NO,
+                                        ARFeedPartnerAdminKey : @{@"id" : @"1234", @"_id":@"1234", @"name" : @"tester", @"default_profile_id" : @"uniqueusername"},
+                                        ARFeedPartnerFlagsKey : @{@"last_folio_access" : @"2016-02-10", @"last_cms_access": @"2015-07-28T21:24:54.495+00:00"},
+                                        ARFeedPartnerSubscriptionPlansNameKey : @[@"standard"]
+                                       }
+                           inContext: context];
 });
 
 it(@"current partner gets first partner in context", ^{

--- a/ArtsyFolio Tests/Testing Util Objects/AROHHTTPNoStubAssertionBot.m
+++ b/ArtsyFolio Tests/Testing Util Objects/AROHHTTPNoStubAssertionBot.m
@@ -61,7 +61,7 @@
         printf("   Stack trace: %s\n\n\n\n", [stackTrace componentsJoinedByString:@"\n                "].UTF8String);
     }
 
-    XCTFail(spectaExample, @"Failed due to unstubbed networking.");
+    _XCTPrimitiveFail(spectaExample, @"Failed due to unstubbed networking.");
     return nil;
 }
 

--- a/Classes/Models/Generated/_Album.h
+++ b/Classes/Models/Generated/_Album.h
@@ -3,7 +3,6 @@
 
 #import <CoreData/CoreData.h>
 #import "ARManagedObject.h"
-
 extern const struct AlbumAttributes {
     __unsafe_unretained NSString *createdAt;
     __unsafe_unretained NSString *editable;
@@ -38,11 +37,8 @@ extern const struct AlbumRelationships {
 @interface _Album : ARManagedObject {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (AlbumID *)objectID;
 
 @property (nonatomic, strong) NSDate *createdAt;
@@ -57,17 +53,13 @@ extern const struct AlbumRelationships {
 @property (nonatomic, strong) NSDate *updatedAt;
 
 @property (nonatomic, strong) NSSet *artists;
-
 - (NSMutableSet *)artistsSet;
 
 @property (nonatomic, strong) NSSet *artworks;
-
 - (NSMutableSet *)artworksSet;
-
 @property (nonatomic, strong) Image *cover;
 
 @property (nonatomic, strong) NSSet *documents;
-
 - (NSMutableSet *)documentsSet;
 
 @end
@@ -75,33 +67,24 @@ extern const struct AlbumRelationships {
 
 @interface _Album (ArtistsCoreDataGeneratedAccessors)
 - (void)addArtists:(NSSet *)value_;
-
 - (void)removeArtists:(NSSet *)value_;
-
 - (void)addArtistsObject:(Artist *)value_;
-
 - (void)removeArtistsObject:(Artist *)value_;
 @end
 
 
 @interface _Album (ArtworksCoreDataGeneratedAccessors)
 - (void)addArtworks:(NSSet *)value_;
-
 - (void)removeArtworks:(NSSet *)value_;
-
 - (void)addArtworksObject:(Artwork *)value_;
-
 - (void)removeArtworksObject:(Artwork *)value_;
 @end
 
 
 @interface _Album (DocumentsCoreDataGeneratedAccessors)
 - (void)addDocuments:(NSSet *)value_;
-
 - (void)removeDocuments:(NSSet *)value_;
-
 - (void)addDocumentsObject:(Document *)value_;
-
 - (void)removeDocumentsObject:(Document *)value_;
 @end
 
@@ -109,55 +92,42 @@ extern const struct AlbumRelationships {
 @interface _Album (CoreDataGeneratedPrimitiveAccessors)
 
 - (NSDate *)primitiveCreatedAt;
-
 - (void)setPrimitiveCreatedAt:(NSDate *)value;
 
 - (NSNumber *)primitiveEditable;
-
 - (void)setPrimitiveEditable:(NSNumber *)value;
 
 - (NSNumber *)primitiveHasBeenEdited;
-
 - (void)setPrimitiveHasBeenEdited:(NSNumber *)value;
 
 - (NSNumber *)primitiveIsPrivate;
-
 - (void)setPrimitiveIsPrivate:(NSNumber *)value;
 
 - (NSString *)primitiveName;
-
 - (void)setPrimitiveName:(NSString *)value;
 
 - (NSString *)primitiveSlug;
-
 - (void)setPrimitiveSlug:(NSString *)value;
 
 - (NSNumber *)primitiveSortKey;
-
 - (void)setPrimitiveSortKey:(NSNumber *)value;
 
 - (NSString *)primitiveSummary;
-
 - (void)setPrimitiveSummary:(NSString *)value;
 
 - (NSDate *)primitiveUpdatedAt;
-
 - (void)setPrimitiveUpdatedAt:(NSDate *)value;
 
 - (NSMutableSet *)primitiveArtists;
-
 - (void)setPrimitiveArtists:(NSMutableSet *)value;
 
 - (NSMutableSet *)primitiveArtworks;
-
 - (void)setPrimitiveArtworks:(NSMutableSet *)value;
 
 - (Image *)primitiveCover;
-
 - (void)setPrimitiveCover:(Image *)value;
 
 - (NSMutableSet *)primitiveDocuments;
-
 - (void)setPrimitiveDocuments:(NSMutableSet *)value;
 
 @end

--- a/Classes/Models/Generated/_Album.m
+++ b/Classes/Models/Generated/_Album.m
@@ -64,7 +64,6 @@ const struct AlbumRelationships AlbumRelationships = {
 @dynamic updatedAt;
 
 @dynamic artists;
-
 - (NSMutableSet *)artistsSet
 {
     [self willAccessValueForKey:@"artists"];
@@ -74,7 +73,6 @@ const struct AlbumRelationships AlbumRelationships = {
 }
 
 @dynamic artworks;
-
 - (NSMutableSet *)artworksSet
 {
     [self willAccessValueForKey:@"artworks"];
@@ -85,7 +83,6 @@ const struct AlbumRelationships AlbumRelationships = {
 
 @dynamic cover;
 @dynamic documents;
-
 - (NSMutableSet *)documentsSet
 {
     [self willAccessValueForKey:@"documents"];

--- a/Classes/Models/Generated/_Artist.h
+++ b/Classes/Models/Generated/_Artist.h
@@ -3,7 +3,6 @@
 
 #import <CoreData/CoreData.h>
 #import "ARManagedObject.h"
-
 extern const struct ArtistAttributes {
     __unsafe_unretained NSString *awards;
     __unsafe_unretained NSString *biography;
@@ -50,11 +49,8 @@ extern const struct ArtistRelationships {
 @interface _Artist : ARManagedObject {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (ArtistID *)objectID;
 
 @property (nonatomic, strong) NSString *awards;
@@ -77,23 +73,17 @@ extern const struct ArtistRelationships {
 @property (nonatomic, strong) NSString *years;
 
 @property (nonatomic, strong) NSSet *albumsFeaturingArtist;
-
 - (NSMutableSet *)albumsFeaturingArtistSet;
 
 @property (nonatomic, strong) NSSet *artworks;
-
 - (NSMutableSet *)artworksSet;
-
 @property (nonatomic, strong) Image *cover;
 
 @property (nonatomic, strong) NSSet *documents;
-
 - (NSMutableSet *)documentsSet;
-
 @property (nonatomic, strong) Image *installShotsFeaturingArtist;
 
 @property (nonatomic, strong) NSSet *showsFeaturingArtist;
-
 - (NSMutableSet *)showsFeaturingArtistSet;
 
 @end
@@ -101,44 +91,32 @@ extern const struct ArtistRelationships {
 
 @interface _Artist (AlbumsFeaturingArtistCoreDataGeneratedAccessors)
 - (void)addAlbumsFeaturingArtist:(NSSet *)value_;
-
 - (void)removeAlbumsFeaturingArtist:(NSSet *)value_;
-
 - (void)addAlbumsFeaturingArtistObject:(Album *)value_;
-
 - (void)removeAlbumsFeaturingArtistObject:(Album *)value_;
 @end
 
 
 @interface _Artist (ArtworksCoreDataGeneratedAccessors)
 - (void)addArtworks:(NSSet *)value_;
-
 - (void)removeArtworks:(NSSet *)value_;
-
 - (void)addArtworksObject:(Artwork *)value_;
-
 - (void)removeArtworksObject:(Artwork *)value_;
 @end
 
 
 @interface _Artist (DocumentsCoreDataGeneratedAccessors)
 - (void)addDocuments:(NSSet *)value_;
-
 - (void)removeDocuments:(NSSet *)value_;
-
 - (void)addDocumentsObject:(Document *)value_;
-
 - (void)removeDocumentsObject:(Document *)value_;
 @end
 
 
 @interface _Artist (ShowsFeaturingArtistCoreDataGeneratedAccessors)
 - (void)addShowsFeaturingArtist:(NSSet *)value_;
-
 - (void)removeShowsFeaturingArtist:(NSSet *)value_;
-
 - (void)addShowsFeaturingArtistObject:(Show *)value_;
-
 - (void)removeShowsFeaturingArtistObject:(Show *)value_;
 @end
 
@@ -146,99 +124,75 @@ extern const struct ArtistRelationships {
 @interface _Artist (CoreDataGeneratedPrimitiveAccessors)
 
 - (NSString *)primitiveAwards;
-
 - (void)setPrimitiveAwards:(NSString *)value;
 
 - (NSString *)primitiveBiography;
-
 - (void)setPrimitiveBiography:(NSString *)value;
 
 - (NSString *)primitiveBlurb;
-
 - (void)setPrimitiveBlurb:(NSString *)value;
 
 - (NSDate *)primitiveCreatedAt;
-
 - (void)setPrimitiveCreatedAt:(NSDate *)value;
 
 - (NSDate *)primitiveDeathDate;
-
 - (void)setPrimitiveDeathDate:(NSDate *)value;
 
 - (NSString *)primitiveDisplayName;
-
 - (void)setPrimitiveDisplayName:(NSString *)value;
 
 - (NSString *)primitiveFirstName;
-
 - (void)setPrimitiveFirstName:(NSString *)value;
 
 - (NSString *)primitiveHometown;
-
 - (void)setPrimitiveHometown:(NSString *)value;
 
 - (NSString *)primitiveLastName;
-
 - (void)setPrimitiveLastName:(NSString *)value;
 
 - (NSString *)primitiveMiddleName;
-
 - (void)setPrimitiveMiddleName:(NSString *)value;
 
 - (NSString *)primitiveName;
-
 - (void)setPrimitiveName:(NSString *)value;
 
 - (NSString *)primitiveNationality;
-
 - (void)setPrimitiveNationality:(NSString *)value;
 
 - (NSString *)primitiveOrderingKey;
-
 - (void)setPrimitiveOrderingKey:(NSString *)value;
 
 - (NSString *)primitiveSlug;
-
 - (void)setPrimitiveSlug:(NSString *)value;
 
 - (NSString *)primitiveStatement;
-
 - (void)setPrimitiveStatement:(NSString *)value;
 
 - (NSString *)primitiveThumbnailBaseURL;
-
 - (void)setPrimitiveThumbnailBaseURL:(NSString *)value;
 
 - (NSDate *)primitiveUpdatedAt;
-
 - (void)setPrimitiveUpdatedAt:(NSDate *)value;
 
 - (NSString *)primitiveYears;
-
 - (void)setPrimitiveYears:(NSString *)value;
 
 - (NSMutableSet *)primitiveAlbumsFeaturingArtist;
-
 - (void)setPrimitiveAlbumsFeaturingArtist:(NSMutableSet *)value;
 
 - (NSMutableSet *)primitiveArtworks;
-
 - (void)setPrimitiveArtworks:(NSMutableSet *)value;
 
 - (Image *)primitiveCover;
-
 - (void)setPrimitiveCover:(Image *)value;
 
 - (NSMutableSet *)primitiveDocuments;
-
 - (void)setPrimitiveDocuments:(NSMutableSet *)value;
 
 - (Image *)primitiveInstallShotsFeaturingArtist;
-
 - (void)setPrimitiveInstallShotsFeaturingArtist:(Image *)value;
 
 - (NSMutableSet *)primitiveShowsFeaturingArtist;
-
 - (void)setPrimitiveShowsFeaturingArtist:(NSMutableSet *)value;
 
 @end

--- a/Classes/Models/Generated/_Artist.m
+++ b/Classes/Models/Generated/_Artist.m
@@ -82,7 +82,6 @@ const struct ArtistRelationships ArtistRelationships = {
 @dynamic years;
 
 @dynamic albumsFeaturingArtist;
-
 - (NSMutableSet *)albumsFeaturingArtistSet
 {
     [self willAccessValueForKey:@"albumsFeaturingArtist"];
@@ -92,7 +91,6 @@ const struct ArtistRelationships ArtistRelationships = {
 }
 
 @dynamic artworks;
-
 - (NSMutableSet *)artworksSet
 {
     [self willAccessValueForKey:@"artworks"];
@@ -103,7 +101,6 @@ const struct ArtistRelationships ArtistRelationships = {
 
 @dynamic cover;
 @dynamic documents;
-
 - (NSMutableSet *)documentsSet
 {
     [self willAccessValueForKey:@"documents"];
@@ -114,7 +111,6 @@ const struct ArtistRelationships ArtistRelationships = {
 
 @dynamic installShotsFeaturingArtist;
 @dynamic showsFeaturingArtist;
-
 - (NSMutableSet *)showsFeaturingArtistSet
 {
     [self willAccessValueForKey:@"showsFeaturingArtist"];

--- a/Classes/Models/Generated/_ArtistDocument.h
+++ b/Classes/Models/Generated/_ArtistDocument.h
@@ -13,11 +13,8 @@
 @interface _ArtistDocument : Document {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (ArtistDocumentID *)objectID;
 
 @end

--- a/Classes/Models/Generated/_Artwork.h
+++ b/Classes/Models/Generated/_Artwork.h
@@ -3,7 +3,6 @@
 
 #import <CoreData/CoreData.h>
 #import "ARManagedObject.h"
-
 extern const struct ArtworkAttributes {
     __unsafe_unretained NSString *availability;
     __unsafe_unretained NSString *backendPrice;
@@ -70,11 +69,8 @@ extern const struct ArtworkRelationships {
 @interface _Artwork : ARManagedObject {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (ArtworkID *)objectID;
 
 @property (nonatomic, strong) NSString *availability;
@@ -110,31 +106,24 @@ extern const struct ArtworkRelationships {
 @property (nonatomic, strong) Artist *artist;
 
 @property (nonatomic, strong) NSSet *collections;
-
 - (NSMutableSet *)collectionsSet;
 
 @property (nonatomic, strong) NSSet *editionSets;
-
 - (NSMutableSet *)editionSetsSet;
 
 @property (nonatomic, strong) NSSet *images;
-
 - (NSMutableSet *)imagesSet;
 
 @property (nonatomic, strong) NSSet *installShotsFeaturingArtwork;
-
 - (NSMutableSet *)installShotsFeaturingArtworkSet;
 
 @property (nonatomic, strong) NSSet *locations;
-
 - (NSMutableSet *)locationsSet;
-
 @property (nonatomic, strong) Image *mainImage;
 @property (nonatomic, strong) Note *notes;
 @property (nonatomic, strong) Partner *partner;
 
 @property (nonatomic, strong) NSSet *shows;
-
 - (NSMutableSet *)showsSet;
 
 @end
@@ -142,66 +131,48 @@ extern const struct ArtworkRelationships {
 
 @interface _Artwork (CollectionsCoreDataGeneratedAccessors)
 - (void)addCollections:(NSSet *)value_;
-
 - (void)removeCollections:(NSSet *)value_;
-
 - (void)addCollectionsObject:(Album *)value_;
-
 - (void)removeCollectionsObject:(Album *)value_;
 @end
 
 
 @interface _Artwork (EditionSetsCoreDataGeneratedAccessors)
 - (void)addEditionSets:(NSSet *)value_;
-
 - (void)removeEditionSets:(NSSet *)value_;
-
 - (void)addEditionSetsObject:(EditionSet *)value_;
-
 - (void)removeEditionSetsObject:(EditionSet *)value_;
 @end
 
 
 @interface _Artwork (ImagesCoreDataGeneratedAccessors)
 - (void)addImages:(NSSet *)value_;
-
 - (void)removeImages:(NSSet *)value_;
-
 - (void)addImagesObject:(Image *)value_;
-
 - (void)removeImagesObject:(Image *)value_;
 @end
 
 
 @interface _Artwork (InstallShotsFeaturingArtworkCoreDataGeneratedAccessors)
 - (void)addInstallShotsFeaturingArtwork:(NSSet *)value_;
-
 - (void)removeInstallShotsFeaturingArtwork:(NSSet *)value_;
-
 - (void)addInstallShotsFeaturingArtworkObject:(Image *)value_;
-
 - (void)removeInstallShotsFeaturingArtworkObject:(Image *)value_;
 @end
 
 
 @interface _Artwork (LocationsCoreDataGeneratedAccessors)
 - (void)addLocations:(NSSet *)value_;
-
 - (void)removeLocations:(NSSet *)value_;
-
 - (void)addLocationsObject:(Location *)value_;
-
 - (void)removeLocationsObject:(Location *)value_;
 @end
 
 
 @interface _Artwork (ShowsCoreDataGeneratedAccessors)
 - (void)addShows:(NSSet *)value_;
-
 - (void)removeShows:(NSSet *)value_;
-
 - (void)addShowsObject:(Show *)value_;
-
 - (void)removeShowsObject:(Show *)value_;
 @end
 
@@ -209,163 +180,123 @@ extern const struct ArtworkRelationships {
 @interface _Artwork (CoreDataGeneratedPrimitiveAccessors)
 
 - (NSString *)primitiveAvailability;
-
 - (void)setPrimitiveAvailability:(NSString *)value;
 
 - (NSString *)primitiveBackendPrice;
-
 - (void)setPrimitiveBackendPrice:(NSString *)value;
 
 - (NSString *)primitiveCategory;
-
 - (void)setPrimitiveCategory:(NSString *)value;
 
 - (NSString *)primitiveConfidentialNotes;
-
 - (void)setPrimitiveConfidentialNotes:(NSString *)value;
 
 - (NSDate *)primitiveCreatedAt;
-
 - (void)setPrimitiveCreatedAt:(NSDate *)value;
 
 - (NSString *)primitiveDate;
-
 - (void)setPrimitiveDate:(NSString *)value;
 
 - (NSDecimalNumber *)primitiveDepth;
-
 - (void)setPrimitiveDepth:(NSDecimalNumber *)value;
 
 - (NSDecimalNumber *)primitiveDiameter;
-
 - (void)setPrimitiveDiameter:(NSDecimalNumber *)value;
 
 - (NSString *)primitiveDimensionsCM;
-
 - (void)setPrimitiveDimensionsCM:(NSString *)value;
 
 - (NSString *)primitiveDimensionsInches;
-
 - (void)setPrimitiveDimensionsInches:(NSString *)value;
 
 - (NSString *)primitiveDisplayPrice;
-
 - (void)setPrimitiveDisplayPrice:(NSString *)value;
 
 - (NSString *)primitiveDisplayTitle;
-
 - (void)setPrimitiveDisplayTitle:(NSString *)value;
 
 - (NSString *)primitiveEditions;
-
 - (void)setPrimitiveEditions:(NSString *)value;
 
 - (NSString *)primitiveExhibitionHistory;
-
 - (void)setPrimitiveExhibitionHistory:(NSString *)value;
 
 - (NSDecimalNumber *)primitiveHeight;
-
 - (void)setPrimitiveHeight:(NSDecimalNumber *)value;
 
 - (NSString *)primitiveImageRights;
-
 - (void)setPrimitiveImageRights:(NSString *)value;
 
 - (NSString *)primitiveInfo;
-
 - (void)setPrimitiveInfo:(NSString *)value;
 
 - (NSString *)primitiveInventoryID;
-
 - (void)setPrimitiveInventoryID:(NSString *)value;
 
 - (NSNumber *)primitiveIsAvailableForSale;
-
 - (void)setPrimitiveIsAvailableForSale:(NSNumber *)value;
 
 - (NSNumber *)primitiveIsPriceHidden;
-
 - (void)setPrimitiveIsPriceHidden:(NSNumber *)value;
 
 - (NSNumber *)primitiveIsPublished;
-
 - (void)setPrimitiveIsPublished:(NSNumber *)value;
 
 - (NSString *)primitiveLiterature;
-
 - (void)setPrimitiveLiterature:(NSString *)value;
 
 - (NSString *)primitiveMedium;
-
 - (void)setPrimitiveMedium:(NSString *)value;
 
 - (NSString *)primitiveProvenance;
-
 - (void)setPrimitiveProvenance:(NSString *)value;
 
 - (NSString *)primitiveSeries;
-
 - (void)setPrimitiveSeries:(NSString *)value;
 
 - (NSString *)primitiveSignature;
-
 - (void)setPrimitiveSignature:(NSString *)value;
 
 - (NSString *)primitiveSlug;
-
 - (void)setPrimitiveSlug:(NSString *)value;
 
 - (NSString *)primitiveTitle;
-
 - (void)setPrimitiveTitle:(NSString *)value;
 
 - (NSDate *)primitiveUpdatedAt;
-
 - (void)setPrimitiveUpdatedAt:(NSDate *)value;
 
 - (NSDecimalNumber *)primitiveWidth;
-
 - (void)setPrimitiveWidth:(NSDecimalNumber *)value;
 
 - (Artist *)primitiveArtist;
-
 - (void)setPrimitiveArtist:(Artist *)value;
 
 - (NSMutableSet *)primitiveCollections;
-
 - (void)setPrimitiveCollections:(NSMutableSet *)value;
 
 - (NSMutableSet *)primitiveEditionSets;
-
 - (void)setPrimitiveEditionSets:(NSMutableSet *)value;
 
 - (NSMutableSet *)primitiveImages;
-
 - (void)setPrimitiveImages:(NSMutableSet *)value;
 
 - (NSMutableSet *)primitiveInstallShotsFeaturingArtwork;
-
 - (void)setPrimitiveInstallShotsFeaturingArtwork:(NSMutableSet *)value;
 
 - (NSMutableSet *)primitiveLocations;
-
 - (void)setPrimitiveLocations:(NSMutableSet *)value;
 
 - (Image *)primitiveMainImage;
-
 - (void)setPrimitiveMainImage:(Image *)value;
 
 - (Note *)primitiveNotes;
-
 - (void)setPrimitiveNotes:(Note *)value;
 
 - (Partner *)primitivePartner;
-
 - (void)setPrimitivePartner:(Partner *)value;
 
 - (NSMutableSet *)primitiveShows;
-
 - (void)setPrimitiveShows:(NSMutableSet *)value;
 
 @end

--- a/Classes/Models/Generated/_Artwork.m
+++ b/Classes/Models/Generated/_Artwork.m
@@ -111,7 +111,6 @@ const struct ArtworkRelationships ArtworkRelationships = {
 
 @dynamic artist;
 @dynamic collections;
-
 - (NSMutableSet *)collectionsSet
 {
     [self willAccessValueForKey:@"collections"];
@@ -121,7 +120,6 @@ const struct ArtworkRelationships ArtworkRelationships = {
 }
 
 @dynamic editionSets;
-
 - (NSMutableSet *)editionSetsSet
 {
     [self willAccessValueForKey:@"editionSets"];
@@ -131,7 +129,6 @@ const struct ArtworkRelationships ArtworkRelationships = {
 }
 
 @dynamic images;
-
 - (NSMutableSet *)imagesSet
 {
     [self willAccessValueForKey:@"images"];
@@ -141,7 +138,6 @@ const struct ArtworkRelationships ArtworkRelationships = {
 }
 
 @dynamic installShotsFeaturingArtwork;
-
 - (NSMutableSet *)installShotsFeaturingArtworkSet
 {
     [self willAccessValueForKey:@"installShotsFeaturingArtwork"];
@@ -151,7 +147,6 @@ const struct ArtworkRelationships ArtworkRelationships = {
 }
 
 @dynamic locations;
-
 - (NSMutableSet *)locationsSet
 {
     [self willAccessValueForKey:@"locations"];
@@ -164,7 +159,6 @@ const struct ArtworkRelationships ArtworkRelationships = {
 @dynamic notes;
 @dynamic partner;
 @dynamic shows;
-
 - (NSMutableSet *)showsSet
 {
     [self willAccessValueForKey:@"shows"];

--- a/Classes/Models/Generated/_Document.h
+++ b/Classes/Models/Generated/_Document.h
@@ -3,7 +3,6 @@
 
 #import <CoreData/CoreData.h>
 #import "ARManagedObject.h"
-
 extern const struct DocumentAttributes {
     __unsafe_unretained NSString *filename;
     __unsafe_unretained NSString *hasFile;
@@ -34,11 +33,8 @@ extern const struct DocumentRelationships {
 @interface _Document : ARManagedObject {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (DocumentID *)objectID;
 
 @property (nonatomic, strong) NSString *filename;
@@ -59,47 +55,36 @@ extern const struct DocumentRelationships {
 @interface _Document (CoreDataGeneratedPrimitiveAccessors)
 
 - (NSString *)primitiveFilename;
-
 - (void)setPrimitiveFilename:(NSString *)value;
 
 - (NSNumber *)primitiveHasFile;
-
 - (void)setPrimitiveHasFile:(NSNumber *)value;
 
 - (NSString *)primitiveHumanReadableSize;
-
 - (void)setPrimitiveHumanReadableSize:(NSString *)value;
 
 - (NSNumber *)primitiveSize;
-
 - (void)setPrimitiveSize:(NSNumber *)value;
 
 - (NSString *)primitiveSlug;
-
 - (void)setPrimitiveSlug:(NSString *)value;
 
 - (NSString *)primitiveTitle;
-
 - (void)setPrimitiveTitle:(NSString *)value;
 
 - (NSString *)primitiveUrl;
-
 - (void)setPrimitiveUrl:(NSString *)value;
 
 - (NSNumber *)primitiveVersion;
-
 - (void)setPrimitiveVersion:(NSNumber *)value;
 
 - (Album *)primitiveAlbum;
-
 - (void)setPrimitiveAlbum:(Album *)value;
 
 - (Artist *)primitiveArtist;
-
 - (void)setPrimitiveArtist:(Artist *)value;
 
 - (Show *)primitiveShow;
-
 - (void)setPrimitiveShow:(Show *)value;
 
 @end

--- a/Classes/Models/Generated/_EditionSet.h
+++ b/Classes/Models/Generated/_EditionSet.h
@@ -3,7 +3,6 @@
 
 #import <CoreData/CoreData.h>
 #import "ARManagedObject.h"
-
 extern const struct EditionSetAttributes {
     __unsafe_unretained NSString *artistProofs;
     __unsafe_unretained NSString *availability;
@@ -40,11 +39,8 @@ extern const struct EditionSetRelationships {
 @interface _EditionSet : ARManagedObject {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (EditionSetID *)objectID;
 
 @property (nonatomic, strong) NSString *artistProofs;

--- a/Classes/Models/Generated/_Image.h
+++ b/Classes/Models/Generated/_Image.h
@@ -3,7 +3,6 @@
 
 #import <CoreData/CoreData.h>
 #import "ARManagedObject.h"
-
 extern const struct ImageAttributes {
     __unsafe_unretained NSString *aspectRatio;
     __unsafe_unretained NSString *baseURL;
@@ -48,11 +47,8 @@ extern const struct ImageRelationships {
 @interface _Image : ARManagedObject {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (ImageID *)objectID;
 
 @property (nonatomic, strong) NSNumber *aspectRatio;
@@ -83,87 +79,66 @@ extern const struct ImageRelationships {
 @interface _Image (CoreDataGeneratedPrimitiveAccessors)
 
 - (NSNumber *)primitiveAspectRatio;
-
 - (void)setPrimitiveAspectRatio:(NSNumber *)value;
 
 - (NSString *)primitiveBaseURL;
-
 - (void)setPrimitiveBaseURL:(NSString *)value;
 
 - (NSNumber *)primitiveIsMainImage;
-
 - (void)setPrimitiveIsMainImage:(NSNumber *)value;
 
 - (NSNumber *)primitiveMaxTiledHeight;
-
 - (void)setPrimitiveMaxTiledHeight:(NSNumber *)value;
 
 - (NSNumber *)primitiveMaxTiledWidth;
-
 - (void)setPrimitiveMaxTiledWidth:(NSNumber *)value;
 
 - (NSNumber *)primitiveOriginalHeight;
-
 - (void)setPrimitiveOriginalHeight:(NSNumber *)value;
 
 - (NSNumber *)primitiveOriginalWidth;
-
 - (void)setPrimitiveOriginalWidth:(NSNumber *)value;
 
 - (NSNumber *)primitivePosition;
-
 - (void)setPrimitivePosition:(NSNumber *)value;
 
 - (NSNumber *)primitiveProcessing;
-
 - (void)setPrimitiveProcessing:(NSNumber *)value;
 
 - (NSString *)primitiveSlug;
-
 - (void)setPrimitiveSlug:(NSString *)value;
 
 - (NSString *)primitiveTileBaseUrl;
-
 - (void)setPrimitiveTileBaseUrl:(NSString *)value;
 
 - (NSString *)primitiveTileFormat;
-
 - (void)setPrimitiveTileFormat:(NSString *)value;
 
 - (NSNumber *)primitiveTileOverlap;
-
 - (void)setPrimitiveTileOverlap:(NSNumber *)value;
 
 - (NSNumber *)primitiveTileSize;
-
 - (void)setPrimitiveTileSize:(NSNumber *)value;
 
 - (Artist *)primitiveArtistsInImage;
-
 - (void)setPrimitiveArtistsInImage:(Artist *)value;
 
 - (Artwork *)primitiveArtwork;
-
 - (void)setPrimitiveArtwork:(Artwork *)value;
 
 - (Artwork *)primitiveArtworksInImage;
-
 - (void)setPrimitiveArtworksInImage:(Artwork *)value;
 
 - (Album *)primitiveCoverForAlbum;
-
 - (void)setPrimitiveCoverForAlbum:(Album *)value;
 
 - (Artist *)primitiveCoverForArtist;
-
 - (void)setPrimitiveCoverForArtist:(Artist *)value;
 
 - (Show *)primitiveCoverForShow;
-
 - (void)setPrimitiveCoverForShow:(Show *)value;
 
 - (Artwork *)primitiveMainImageForArtwork;
-
 - (void)setPrimitiveMainImageForArtwork:(Artwork *)value;
 
 @end

--- a/Classes/Models/Generated/_InstallShotImage.h
+++ b/Classes/Models/Generated/_InstallShotImage.h
@@ -23,11 +23,8 @@ extern const struct InstallShotImageRelationships {
 @interface _InstallShotImage : Image {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (InstallShotImageID *)objectID;
 
 @property (nonatomic, strong) NSString *caption;
@@ -39,11 +36,9 @@ extern const struct InstallShotImageRelationships {
 @interface _InstallShotImage (CoreDataGeneratedPrimitiveAccessors)
 
 - (NSString *)primitiveCaption;
-
 - (void)setPrimitiveCaption:(NSString *)value;
 
 - (Show *)primitiveShowWithImageInInstallation;
-
 - (void)setPrimitiveShowWithImageInInstallation:(Show *)value;
 
 @end

--- a/Classes/Models/Generated/_LocalImage.h
+++ b/Classes/Models/Generated/_LocalImage.h
@@ -13,11 +13,8 @@
 @interface _LocalImage : Image {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (LocalImageID *)objectID;
 
 @end

--- a/Classes/Models/Generated/_Location.h
+++ b/Classes/Models/Generated/_Location.h
@@ -3,7 +3,6 @@
 
 #import <CoreData/CoreData.h>
 #import "ARManagedObject.h"
-
 extern const struct LocationAttributes {
     __unsafe_unretained NSString *address;
     __unsafe_unretained NSString *addressSecond;
@@ -33,11 +32,8 @@ extern const struct LocationRelationships {
 @interface _Location : ARManagedObject {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (LocationID *)objectID;
 
 @property (nonatomic, strong) NSString *address;
@@ -51,11 +47,9 @@ extern const struct LocationRelationships {
 @property (nonatomic, strong) NSString *state;
 
 @property (nonatomic, strong) NSSet *artworks;
-
 - (NSMutableSet *)artworksSet;
 
 @property (nonatomic, strong) NSSet *shows;
-
 - (NSMutableSet *)showsSet;
 
 @end
@@ -63,22 +57,16 @@ extern const struct LocationRelationships {
 
 @interface _Location (ArtworksCoreDataGeneratedAccessors)
 - (void)addArtworks:(NSSet *)value_;
-
 - (void)removeArtworks:(NSSet *)value_;
-
 - (void)addArtworksObject:(Artwork *)value_;
-
 - (void)removeArtworksObject:(Artwork *)value_;
 @end
 
 
 @interface _Location (ShowsCoreDataGeneratedAccessors)
 - (void)addShows:(NSSet *)value_;
-
 - (void)removeShows:(NSSet *)value_;
-
 - (void)addShowsObject:(Show *)value_;
-
 - (void)removeShowsObject:(Show *)value_;
 @end
 
@@ -86,47 +74,36 @@ extern const struct LocationRelationships {
 @interface _Location (CoreDataGeneratedPrimitiveAccessors)
 
 - (NSString *)primitiveAddress;
-
 - (void)setPrimitiveAddress:(NSString *)value;
 
 - (NSString *)primitiveAddressSecond;
-
 - (void)setPrimitiveAddressSecond:(NSString *)value;
 
 - (NSString *)primitiveCity;
-
 - (void)setPrimitiveCity:(NSString *)value;
 
 - (NSString *)primitiveGeoPoint;
-
 - (void)setPrimitiveGeoPoint:(NSString *)value;
 
 - (NSString *)primitiveName;
-
 - (void)setPrimitiveName:(NSString *)value;
 
 - (NSString *)primitivePhone;
-
 - (void)setPrimitivePhone:(NSString *)value;
 
 - (NSString *)primitivePostalCode;
-
 - (void)setPrimitivePostalCode:(NSString *)value;
 
 - (NSString *)primitiveSlug;
-
 - (void)setPrimitiveSlug:(NSString *)value;
 
 - (NSString *)primitiveState;
-
 - (void)setPrimitiveState:(NSString *)value;
 
 - (NSMutableSet *)primitiveArtworks;
-
 - (void)setPrimitiveArtworks:(NSMutableSet *)value;
 
 - (NSMutableSet *)primitiveShows;
-
 - (void)setPrimitiveShows:(NSMutableSet *)value;
 
 @end

--- a/Classes/Models/Generated/_Location.m
+++ b/Classes/Models/Generated/_Location.m
@@ -60,7 +60,6 @@ const struct LocationRelationships LocationRelationships = {
 @dynamic state;
 
 @dynamic artworks;
-
 - (NSMutableSet *)artworksSet
 {
     [self willAccessValueForKey:@"artworks"];
@@ -70,7 +69,6 @@ const struct LocationRelationships LocationRelationships = {
 }
 
 @dynamic shows;
-
 - (NSMutableSet *)showsSet
 {
     [self willAccessValueForKey:@"shows"];

--- a/Classes/Models/Generated/_Note.h
+++ b/Classes/Models/Generated/_Note.h
@@ -3,7 +3,6 @@
 
 #import <CoreData/CoreData.h>
 #import "ARManagedObject.h"
-
 extern const struct NoteAttributes {
     __unsafe_unretained NSString *body;
     __unsafe_unretained NSString *createdAt;
@@ -25,11 +24,8 @@ extern const struct NoteRelationships {
 @interface _Note : ARManagedObject {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (NoteID *)objectID;
 
 @property (nonatomic, strong) NSString *body;
@@ -43,19 +39,15 @@ extern const struct NoteRelationships {
 @interface _Note (CoreDataGeneratedPrimitiveAccessors)
 
 - (NSString *)primitiveBody;
-
 - (void)setPrimitiveBody:(NSString *)value;
 
 - (NSDate *)primitiveCreatedAt;
-
 - (void)setPrimitiveCreatedAt:(NSDate *)value;
 
 - (NSDate *)primitiveUpdatedAt;
-
 - (void)setPrimitiveUpdatedAt:(NSDate *)value;
 
 - (Artwork *)primitiveArtwork;
-
 - (void)setPrimitiveArtwork:(Artwork *)value;
 
 @end

--- a/Classes/Models/Generated/_Partner.h
+++ b/Classes/Models/Generated/_Partner.h
@@ -3,7 +3,6 @@
 
 #import <CoreData/CoreData.h>
 #import "ARManagedObject.h"
-
 extern const struct PartnerAttributes {
     __unsafe_unretained NSString *active;
     __unsafe_unretained NSString *artistDocumentsCount;
@@ -13,7 +12,6 @@ extern const struct PartnerAttributes {
     __unsafe_unretained NSString *createdAt;
     __unsafe_unretained NSString *defaultProfileID;
     __unsafe_unretained NSString *defaultProfilePublic;
-    __unsafe_unretained NSString *directlyContactable;
     __unsafe_unretained NSString *email;
     __unsafe_unretained NSString *foundingPartner;
     __unsafe_unretained NSString *hasDefaultProfile;
@@ -53,11 +51,8 @@ extern const struct PartnerRelationships {
 @interface _Partner : ARManagedObject {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (PartnerID *)objectID;
 
 @property (nonatomic, strong) NSNumber *active;
@@ -68,7 +63,6 @@ extern const struct PartnerRelationships {
 @property (nonatomic, strong) NSDate *createdAt;
 @property (nonatomic, strong) NSString *defaultProfileID;
 @property (nonatomic, strong) NSNumber *defaultProfilePublic;
-@property (nonatomic, strong) NSNumber *directlyContactable;
 @property (nonatomic, strong) NSString *email;
 @property (nonatomic, strong) NSNumber *foundingPartner;
 @property (nonatomic, strong) NSNumber *hasDefaultProfile;
@@ -78,7 +72,7 @@ extern const struct PartnerRelationships {
 @property (nonatomic, strong) NSNumber *partnerLimitedAccess;
 @property (nonatomic, strong) NSString *partnerType;
 @property (nonatomic, strong) NSString *region;
-@property (nonatomic, strong) NSString *relativeSize;
+@property (nonatomic, strong) NSNumber *relativeSize;
 @property (nonatomic, strong) NSString *representativeEmail;
 @property (nonatomic, strong) NSNumber *showDocumentsCount;
 @property (nonatomic, strong) NSString *slug;
@@ -88,15 +82,12 @@ extern const struct PartnerRelationships {
 @property (nonatomic, strong) User *admin;
 
 @property (nonatomic, strong) NSSet *artworks;
-
 - (NSMutableSet *)artworksSet;
 
 @property (nonatomic, strong) NSSet *flags;
-
 - (NSMutableSet *)flagsSet;
 
 @property (nonatomic, strong) NSSet *subscriptionPlans;
-
 - (NSMutableSet *)subscriptionPlansSet;
 
 @end
@@ -104,33 +95,24 @@ extern const struct PartnerRelationships {
 
 @interface _Partner (ArtworksCoreDataGeneratedAccessors)
 - (void)addArtworks:(NSSet *)value_;
-
 - (void)removeArtworks:(NSSet *)value_;
-
 - (void)addArtworksObject:(Artwork *)value_;
-
 - (void)removeArtworksObject:(Artwork *)value_;
 @end
 
 
 @interface _Partner (FlagsCoreDataGeneratedAccessors)
 - (void)addFlags:(NSSet *)value_;
-
 - (void)removeFlags:(NSSet *)value_;
-
 - (void)addFlagsObject:(PartnerOption *)value_;
-
 - (void)removeFlagsObject:(PartnerOption *)value_;
 @end
 
 
 @interface _Partner (SubscriptionPlansCoreDataGeneratedAccessors)
 - (void)addSubscriptionPlans:(NSSet *)value_;
-
 - (void)removeSubscriptionPlans:(NSSet *)value_;
-
 - (void)addSubscriptionPlansObject:(SubscriptionPlan *)value_;
-
 - (void)removeSubscriptionPlansObject:(SubscriptionPlan *)value_;
 @end
 
@@ -138,119 +120,87 @@ extern const struct PartnerRelationships {
 @interface _Partner (CoreDataGeneratedPrimitiveAccessors)
 
 - (NSNumber *)primitiveActive;
-
 - (void)setPrimitiveActive:(NSNumber *)value;
 
 - (NSNumber *)primitiveArtistDocumentsCount;
-
 - (void)setPrimitiveArtistDocumentsCount:(NSNumber *)value;
 
 - (NSNumber *)primitiveArtistsCount;
-
 - (void)setPrimitiveArtistsCount:(NSNumber *)value;
 
 - (NSNumber *)primitiveArtworksCount;
-
 - (void)setPrimitiveArtworksCount:(NSNumber *)value;
 
 - (NSString *)primitiveContractType;
-
 - (void)setPrimitiveContractType:(NSString *)value;
 
 - (NSDate *)primitiveCreatedAt;
-
 - (void)setPrimitiveCreatedAt:(NSDate *)value;
 
 - (NSString *)primitiveDefaultProfileID;
-
 - (void)setPrimitiveDefaultProfileID:(NSString *)value;
 
 - (NSNumber *)primitiveDefaultProfilePublic;
-
 - (void)setPrimitiveDefaultProfilePublic:(NSNumber *)value;
 
-- (NSNumber *)primitiveDirectlyContactable;
-
-- (void)setPrimitiveDirectlyContactable:(NSNumber *)value;
-
 - (NSString *)primitiveEmail;
-
 - (void)setPrimitiveEmail:(NSString *)value;
 
 - (NSNumber *)primitiveFoundingPartner;
-
 - (void)setPrimitiveFoundingPartner:(NSNumber *)value;
 
 - (NSNumber *)primitiveHasDefaultProfile;
-
 - (void)setPrimitiveHasDefaultProfile:(NSNumber *)value;
 
 - (NSNumber *)primitiveHasFullProfile;
-
 - (void)setPrimitiveHasFullProfile:(NSNumber *)value;
 
 - (NSString *)primitiveName;
-
 - (void)setPrimitiveName:(NSString *)value;
 
 - (NSString *)primitivePartnerID;
-
 - (void)setPrimitivePartnerID:(NSString *)value;
 
 - (NSNumber *)primitivePartnerLimitedAccess;
-
 - (void)setPrimitivePartnerLimitedAccess:(NSNumber *)value;
 
 - (NSString *)primitivePartnerType;
-
 - (void)setPrimitivePartnerType:(NSString *)value;
 
 - (NSString *)primitiveRegion;
-
 - (void)setPrimitiveRegion:(NSString *)value;
 
-- (NSString *)primitiveRelativeSize;
-
-- (void)setPrimitiveRelativeSize:(NSString *)value;
+- (NSNumber *)primitiveRelativeSize;
+- (void)setPrimitiveRelativeSize:(NSNumber *)value;
 
 - (NSString *)primitiveRepresentativeEmail;
-
 - (void)setPrimitiveRepresentativeEmail:(NSString *)value;
 
 - (NSNumber *)primitiveShowDocumentsCount;
-
 - (void)setPrimitiveShowDocumentsCount:(NSNumber *)value;
 
 - (NSString *)primitiveSlug;
-
 - (void)setPrimitiveSlug:(NSString *)value;
 
 - (NSString *)primitiveSubscriptionState;
-
 - (void)setPrimitiveSubscriptionState:(NSString *)value;
 
 - (NSDate *)primitiveUpdatedAt;
-
 - (void)setPrimitiveUpdatedAt:(NSDate *)value;
 
 - (NSString *)primitiveWebsite;
-
 - (void)setPrimitiveWebsite:(NSString *)value;
 
 - (User *)primitiveAdmin;
-
 - (void)setPrimitiveAdmin:(User *)value;
 
 - (NSMutableSet *)primitiveArtworks;
-
 - (void)setPrimitiveArtworks:(NSMutableSet *)value;
 
 - (NSMutableSet *)primitiveFlags;
-
 - (void)setPrimitiveFlags:(NSMutableSet *)value;
 
 - (NSMutableSet *)primitiveSubscriptionPlans;
-
 - (void)setPrimitiveSubscriptionPlans:(NSMutableSet *)value;
 
 @end

--- a/Classes/Models/Generated/_Partner.m
+++ b/Classes/Models/Generated/_Partner.m
@@ -12,7 +12,6 @@ const struct PartnerAttributes PartnerAttributes = {
     .createdAt = @"createdAt",
     .defaultProfileID = @"defaultProfileID",
     .defaultProfilePublic = @"defaultProfilePublic",
-    .directlyContactable = @"directlyContactable",
     .email = @"email",
     .foundingPartner = @"foundingPartner",
     .hasDefaultProfile = @"hasDefaultProfile",
@@ -75,7 +74,6 @@ const struct PartnerRelationships PartnerRelationships = {
 @dynamic createdAt;
 @dynamic defaultProfileID;
 @dynamic defaultProfilePublic;
-@dynamic directlyContactable;
 @dynamic email;
 @dynamic foundingPartner;
 @dynamic hasDefaultProfile;
@@ -95,7 +93,6 @@ const struct PartnerRelationships PartnerRelationships = {
 
 @dynamic admin;
 @dynamic artworks;
-
 - (NSMutableSet *)artworksSet
 {
     [self willAccessValueForKey:@"artworks"];
@@ -105,7 +102,6 @@ const struct PartnerRelationships PartnerRelationships = {
 }
 
 @dynamic flags;
-
 - (NSMutableSet *)flagsSet
 {
     [self willAccessValueForKey:@"flags"];
@@ -115,7 +111,6 @@ const struct PartnerRelationships PartnerRelationships = {
 }
 
 @dynamic subscriptionPlans;
-
 - (NSMutableSet *)subscriptionPlansSet
 {
     [self willAccessValueForKey:@"subscriptionPlans"];

--- a/Classes/Models/Generated/_PartnerOption.h
+++ b/Classes/Models/Generated/_PartnerOption.h
@@ -3,7 +3,6 @@
 
 #import <CoreData/CoreData.h>
 #import "ARManagedObject.h"
-
 extern const struct PartnerOptionAttributes {
     __unsafe_unretained NSString *key;
     __unsafe_unretained NSString *value;
@@ -24,11 +23,8 @@ extern const struct PartnerOptionRelationships {
 @interface _PartnerOption : ARManagedObject {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (PartnerOptionID *)objectID;
 
 @property (nonatomic, strong) NSString *key;
@@ -41,15 +37,12 @@ extern const struct PartnerOptionRelationships {
 @interface _PartnerOption (CoreDataGeneratedPrimitiveAccessors)
 
 - (NSString *)primitiveKey;
-
 - (void)setPrimitiveKey:(NSString *)value;
 
 - (NSString *)primitiveValue;
-
 - (void)setPrimitiveValue:(NSString *)value;
 
 - (Partner *)primitivePartner;
-
 - (void)setPrimitivePartner:(Partner *)value;
 
 @end

--- a/Classes/Models/Generated/_Show.h
+++ b/Classes/Models/Generated/_Show.h
@@ -3,7 +3,6 @@
 
 #import <CoreData/CoreData.h>
 #import "ARManagedObject.h"
-
 extern const struct ShowAttributes {
     __unsafe_unretained NSString *availabilityPeriod;
     __unsafe_unretained NSString *createdAt;
@@ -42,11 +41,8 @@ extern const struct ShowRelationships {
 @interface _Show : ARManagedObject {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (ShowID *)objectID;
 
 @property (nonatomic, strong) NSString *availabilityPeriod;
@@ -61,23 +57,17 @@ extern const struct ShowRelationships {
 @property (nonatomic, strong) NSDate *updatedAt;
 
 @property (nonatomic, strong) NSSet *artists;
-
 - (NSMutableSet *)artistsSet;
 
 @property (nonatomic, strong) NSSet *artworks;
-
 - (NSMutableSet *)artworksSet;
-
 @property (nonatomic, strong) Image *cover;
 
 @property (nonatomic, strong) NSSet *documents;
-
 - (NSMutableSet *)documentsSet;
 
 @property (nonatomic, strong) NSSet *installationImages;
-
 - (NSMutableSet *)installationImagesSet;
-
 @property (nonatomic, strong) Location *location;
 
 @end
@@ -85,44 +75,32 @@ extern const struct ShowRelationships {
 
 @interface _Show (ArtistsCoreDataGeneratedAccessors)
 - (void)addArtists:(NSSet *)value_;
-
 - (void)removeArtists:(NSSet *)value_;
-
 - (void)addArtistsObject:(Artist *)value_;
-
 - (void)removeArtistsObject:(Artist *)value_;
 @end
 
 
 @interface _Show (ArtworksCoreDataGeneratedAccessors)
 - (void)addArtworks:(NSSet *)value_;
-
 - (void)removeArtworks:(NSSet *)value_;
-
 - (void)addArtworksObject:(Artwork *)value_;
-
 - (void)removeArtworksObject:(Artwork *)value_;
 @end
 
 
 @interface _Show (DocumentsCoreDataGeneratedAccessors)
 - (void)addDocuments:(NSSet *)value_;
-
 - (void)removeDocuments:(NSSet *)value_;
-
 - (void)addDocumentsObject:(Document *)value_;
-
 - (void)removeDocumentsObject:(Document *)value_;
 @end
 
 
 @interface _Show (InstallationImagesCoreDataGeneratedAccessors)
 - (void)addInstallationImages:(NSSet *)value_;
-
 - (void)removeInstallationImages:(NSSet *)value_;
-
 - (void)addInstallationImagesObject:(InstallShotImage *)value_;
-
 - (void)removeInstallationImagesObject:(InstallShotImage *)value_;
 @end
 
@@ -130,67 +108,51 @@ extern const struct ShowRelationships {
 @interface _Show (CoreDataGeneratedPrimitiveAccessors)
 
 - (NSString *)primitiveAvailabilityPeriod;
-
 - (void)setPrimitiveAvailabilityPeriod:(NSString *)value;
 
 - (NSString *)primitiveCreatedAt;
-
 - (void)setPrimitiveCreatedAt:(NSString *)value;
 
 - (NSDate *)primitiveEndsAt;
-
 - (void)setPrimitiveEndsAt:(NSDate *)value;
 
 - (NSString *)primitiveName;
-
 - (void)setPrimitiveName:(NSString *)value;
 
 - (NSString *)primitiveShowSlug;
-
 - (void)setPrimitiveShowSlug:(NSString *)value;
 
 - (NSString *)primitiveSlug;
-
 - (void)setPrimitiveSlug:(NSString *)value;
 
 - (NSNumber *)primitiveSortKey;
-
 - (void)setPrimitiveSortKey:(NSNumber *)value;
 
 - (NSDate *)primitiveStartsAt;
-
 - (void)setPrimitiveStartsAt:(NSDate *)value;
 
 - (NSString *)primitiveStatus;
-
 - (void)setPrimitiveStatus:(NSString *)value;
 
 - (NSDate *)primitiveUpdatedAt;
-
 - (void)setPrimitiveUpdatedAt:(NSDate *)value;
 
 - (NSMutableSet *)primitiveArtists;
-
 - (void)setPrimitiveArtists:(NSMutableSet *)value;
 
 - (NSMutableSet *)primitiveArtworks;
-
 - (void)setPrimitiveArtworks:(NSMutableSet *)value;
 
 - (Image *)primitiveCover;
-
 - (void)setPrimitiveCover:(Image *)value;
 
 - (NSMutableSet *)primitiveDocuments;
-
 - (void)setPrimitiveDocuments:(NSMutableSet *)value;
 
 - (NSMutableSet *)primitiveInstallationImages;
-
 - (void)setPrimitiveInstallationImages:(NSMutableSet *)value;
 
 - (Location *)primitiveLocation;
-
 - (void)setPrimitiveLocation:(Location *)value;
 
 @end

--- a/Classes/Models/Generated/_Show.m
+++ b/Classes/Models/Generated/_Show.m
@@ -66,7 +66,6 @@ const struct ShowRelationships ShowRelationships = {
 @dynamic updatedAt;
 
 @dynamic artists;
-
 - (NSMutableSet *)artistsSet
 {
     [self willAccessValueForKey:@"artists"];
@@ -76,7 +75,6 @@ const struct ShowRelationships ShowRelationships = {
 }
 
 @dynamic artworks;
-
 - (NSMutableSet *)artworksSet
 {
     [self willAccessValueForKey:@"artworks"];
@@ -87,7 +85,6 @@ const struct ShowRelationships ShowRelationships = {
 
 @dynamic cover;
 @dynamic documents;
-
 - (NSMutableSet *)documentsSet
 {
     [self willAccessValueForKey:@"documents"];
@@ -97,7 +94,6 @@ const struct ShowRelationships ShowRelationships = {
 }
 
 @dynamic installationImages;
-
 - (NSMutableSet *)installationImagesSet
 {
     [self willAccessValueForKey:@"installationImages"];

--- a/Classes/Models/Generated/_ShowDocument.h
+++ b/Classes/Models/Generated/_ShowDocument.h
@@ -13,11 +13,8 @@
 @interface _ShowDocument : Document {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (ShowDocumentID *)objectID;
 
 @end

--- a/Classes/Models/Generated/_SubscriptionPlan.h
+++ b/Classes/Models/Generated/_SubscriptionPlan.h
@@ -3,7 +3,6 @@
 
 #import <CoreData/CoreData.h>
 #import "ARManagedObject.h"
-
 extern const struct SubscriptionPlanAttributes {
     __unsafe_unretained NSString *name;
 } SubscriptionPlanAttributes;
@@ -23,11 +22,8 @@ extern const struct SubscriptionPlanRelationships {
 @interface _SubscriptionPlan : ARManagedObject {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (SubscriptionPlanID *)objectID;
 
 @property (nonatomic, strong) NSString *name;
@@ -39,11 +35,9 @@ extern const struct SubscriptionPlanRelationships {
 @interface _SubscriptionPlan (CoreDataGeneratedPrimitiveAccessors)
 
 - (NSString *)primitiveName;
-
 - (void)setPrimitiveName:(NSString *)value;
 
 - (Partner *)primitiveSubscriptionForPartner;
-
 - (void)setPrimitiveSubscriptionForPartner:(Partner *)value;
 
 @end

--- a/Classes/Models/Generated/_SyncError.h
+++ b/Classes/Models/Generated/_SyncError.h
@@ -3,7 +3,6 @@
 
 #import <CoreData/CoreData.h>
 #import "ARManagedObject.h"
-
 extern const struct SyncErrorAttributes {
     __unsafe_unretained NSString *body;
     __unsafe_unretained NSString *errorType;
@@ -24,11 +23,8 @@ extern const struct SyncErrorRelationships {
 @interface _SyncError : ARManagedObject {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (SyncErrorID *)objectID;
 
 @property (nonatomic, strong) NSString *body;
@@ -41,15 +37,12 @@ extern const struct SyncErrorRelationships {
 @interface _SyncError (CoreDataGeneratedPrimitiveAccessors)
 
 - (NSString *)primitiveBody;
-
 - (void)setPrimitiveBody:(NSString *)value;
 
 - (NSString *)primitiveErrorType;
-
 - (void)setPrimitiveErrorType:(NSString *)value;
 
 - (SyncLog *)primitiveSyncLog;
-
 - (void)setPrimitiveSyncLog:(SyncLog *)value;
 
 @end

--- a/Classes/Models/Generated/_SyncLog.h
+++ b/Classes/Models/Generated/_SyncLog.h
@@ -3,7 +3,6 @@
 
 #import <CoreData/CoreData.h>
 #import "ARManagedObject.h"
-
 extern const struct SyncLogAttributes {
     __unsafe_unretained NSString *albumsDelta;
     __unsafe_unretained NSString *artworkDelta;
@@ -29,11 +28,8 @@ extern const struct SyncLogRelationships {
 @interface _SyncLog : ARManagedObject {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (SyncLogID *)objectID;
 
 @property (nonatomic, strong) NSNumber *albumsDelta;
@@ -51,35 +47,27 @@ extern const struct SyncLogRelationships {
 @interface _SyncLog (CoreDataGeneratedPrimitiveAccessors)
 
 - (NSNumber *)primitiveAlbumsDelta;
-
 - (void)setPrimitiveAlbumsDelta:(NSNumber *)value;
 
 - (NSNumber *)primitiveArtworkDelta;
-
 - (void)setPrimitiveArtworkDelta:(NSNumber *)value;
 
 - (NSDate *)primitiveDateStarted;
-
 - (void)setPrimitiveDateStarted:(NSDate *)value;
 
 - (NSNumber *)primitiveEstimatedDownload;
-
 - (void)setPrimitiveEstimatedDownload:(NSNumber *)value;
 
 - (NSNumber *)primitiveShowDelta;
-
 - (void)setPrimitiveShowDelta:(NSNumber *)value;
 
 - (NSNumber *)primitiveTimeToCompletion;
-
 - (void)setPrimitiveTimeToCompletion:(NSNumber *)value;
 
 - (NSNumber *)primitiveTotalDownloaded;
-
 - (void)setPrimitiveTotalDownloaded:(NSNumber *)value;
 
 - (SyncError *)primitiveSyncErrors;
-
 - (void)setPrimitiveSyncErrors:(SyncError *)value;
 
 @end

--- a/Classes/Models/Generated/_User.h
+++ b/Classes/Models/Generated/_User.h
@@ -3,7 +3,6 @@
 
 #import <CoreData/CoreData.h>
 #import "ARManagedObject.h"
-
 extern const struct UserAttributes {
     __unsafe_unretained NSString *email;
     __unsafe_unretained NSString *name;
@@ -26,11 +25,8 @@ extern const struct UserRelationships {
 @interface _User : ARManagedObject {
 }
 + (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 + (NSString *)entityName;
-
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-
 - (UserID *)objectID;
 
 @property (nonatomic, strong) NSString *email;
@@ -45,19 +41,15 @@ extern const struct UserRelationships {
 @interface _User (CoreDataGeneratedPrimitiveAccessors)
 
 - (NSString *)primitiveEmail;
-
 - (void)setPrimitiveEmail:(NSString *)value;
 
 - (NSString *)primitiveName;
-
 - (void)setPrimitiveName:(NSString *)value;
 
 - (NSString *)primitiveSlug;
-
 - (void)setPrimitiveSlug:(NSString *)value;
 
 - (Partner *)primitiveAdminForPartner;
-
 - (void)setPrimitiveAdminForPartner:(Partner *)value;
 
 @end

--- a/Classes/Models/Partner.m
+++ b/Classes/Models/Partner.m
@@ -25,7 +25,7 @@
     self.subscriptionState = [dict onlyStringForKey:ARFeedPartnerSubscriptionStateKey];
     self.region = [dict onlyStringForKey:ARFeedRegionKey];
     self.partnerLimitedAccess = [dict onlyNumberForKey:ARFeedHasLimitedPartnerToolAccessKey];
-    self.relativeSize = [dict onlyStringForKey:ARFeedRelativeSizeKey];
+    self.relativeSize = [dict onlyNumberForKey:ARFeedRelativeSizeKey];
     self.contractType = [dict onlyStringForKey:ARFeedPartnerContractTypeKey];
     self.hasFullProfile = [dict onlyNumberForKey:ARFeedHasFullProfileKey];
     self.hasDefaultProfile = [dict onlyNumberForKey:ARFeedHasDefaultProfileIDKey];

--- a/Resources/CoreData/ArtsyPartner.xcdatamodeld/.xccurrentversion
+++ b/Resources/CoreData/ArtsyPartner.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>ArtsyFolio v2.4.xcdatamodel</string>
+	<string>ArtsyFolio v2.5.xcdatamodel</string>
 </dict>
 </plist>

--- a/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.5.xcdatamodel/contents
+++ b/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.5.xcdatamodel/contents
@@ -1,0 +1,332 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="1" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9525" systemVersion="15C50" minimumToolsVersion="Automatic">
+    <entity name="Album" representedClassName="Album" elementID="Collection">
+        <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="editable" optional="YES" attributeType="Boolean" defaultValueString="YES" syncable="YES"/>
+        <attribute name="hasBeenEdited" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="isPrivate" optional="YES" attributeType="Boolean">
+            <userInfo/>
+        </attribute>
+        <attribute name="name" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="slug" attributeType="String" defaultValueString="unknown-album" indexed="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="sortKey" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="summary" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <relationship name="artists" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artist" inverseName="albumsFeaturingArtist" inverseEntity="Artist" syncable="YES"/>
+        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="collections" inverseEntity="Artwork">
+            <userInfo/>
+        </relationship>
+        <relationship name="cover" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Image" inverseName="coverForAlbum" inverseEntity="Image" syncable="YES"/>
+        <relationship name="documents" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Document" inverseName="album" inverseEntity="Document" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="Artist" representedClassName="Artist">
+        <attribute name="awards" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="biography" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="blurb" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="deathDate" optional="YES" attributeType="Date">
+            <userInfo/>
+        </attribute>
+        <attribute name="displayName" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="firstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="hometown" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="middleName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="nationality" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="orderingKey" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="slug" attributeType="String" defaultValueString="unknown-artist" indexed="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="statement" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="thumbnailBaseURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="years" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <relationship name="albumsFeaturingArtist" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Album" inverseName="artists" inverseEntity="Album" syncable="YES"/>
+        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="artist" inverseEntity="Artwork">
+            <userInfo/>
+        </relationship>
+        <relationship name="cover" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Image" inverseName="coverForArtist" inverseEntity="Image" syncable="YES"/>
+        <relationship name="documents" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Document" inverseName="artist" inverseEntity="Document" syncable="YES"/>
+        <relationship name="installShotsFeaturingArtist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Image" inverseName="artistsInImage" inverseEntity="Image" syncable="YES"/>
+        <relationship name="showsFeaturingArtist" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Show" inverseName="artists" inverseEntity="Show" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="ArtistDocument" representedClassName="ArtistDocument" parentEntity="Document" syncable="YES"/>
+    <entity name="Artwork" representedClassName="Artwork">
+        <attribute name="availability" optional="YES" attributeType="String" defaultValueString="not for sale" syncable="YES"/>
+        <attribute name="backendPrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="category" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="confidentialNotes" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="date" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="depth" optional="YES" attributeType="Decimal" defaultValueString="0.0">
+            <userInfo/>
+        </attribute>
+        <attribute name="diameter" optional="YES" attributeType="Decimal" defaultValueString="0.0">
+            <userInfo/>
+        </attribute>
+        <attribute name="dimensionsCM" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="dimensionsInches" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="displayPrice" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="displayTitle" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="editions" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="exhibitionHistory" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="height" optional="YES" attributeType="Decimal" defaultValueString="0.0">
+            <userInfo/>
+        </attribute>
+        <attribute name="imageRights" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="info" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="inventoryID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isAvailableForSale" optional="YES" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
+        <attribute name="isPriceHidden" optional="YES" attributeType="Boolean">
+            <userInfo/>
+        </attribute>
+        <attribute name="isPublished" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="literature" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="medium" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="provenance" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="series" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="signature" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="slug" attributeType="String" defaultValueString="unknown-artwork" indexed="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="title" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="width" optional="YES" attributeType="Decimal" defaultValueString="0.0">
+            <userInfo/>
+        </attribute>
+        <relationship name="artist" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="artworks" inverseEntity="Artist">
+            <userInfo/>
+        </relationship>
+        <relationship name="collections" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Album" inverseName="artworks" inverseEntity="Album">
+            <userInfo/>
+        </relationship>
+        <relationship name="editionSets" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="EditionSet" inverseName="artwork" inverseEntity="EditionSet" syncable="YES"/>
+        <relationship name="images" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Image" inverseName="artwork" inverseEntity="Image" syncable="YES"/>
+        <relationship name="installShotsFeaturingArtwork" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Image" inverseName="artworksInImage" inverseEntity="Image" syncable="YES"/>
+        <relationship name="locations" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Location" inverseName="artworks" inverseEntity="Location" syncable="YES"/>
+        <relationship name="mainImage" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Image" inverseName="mainImageForArtwork" inverseEntity="Image" syncable="YES"/>
+        <relationship name="notes" optional="YES" minCount="1" maxCount="1" deletionRule="Cascade" destinationEntity="Note" inverseName="artwork" inverseEntity="Note" syncable="YES"/>
+        <relationship name="partner" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Partner" inverseName="artworks" inverseEntity="Partner">
+            <userInfo/>
+        </relationship>
+        <relationship name="shows" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Show" inverseName="artworks" inverseEntity="Show" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="Document" representedClassName="Document" syncable="YES">
+        <attribute name="filename" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="hasFile" optional="YES" attributeType="Boolean" defaultValueString="YES" syncable="YES"/>
+        <attribute name="humanReadableSize" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="size" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="slug" attributeType="String" defaultValueString="unknown-document" syncable="YES"/>
+        <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="version" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <relationship name="album" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Album" inverseName="documents" inverseEntity="Album" syncable="YES"/>
+        <relationship name="artist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="documents" inverseEntity="Artist" syncable="YES"/>
+        <relationship name="show" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Show" inverseName="documents" inverseEntity="Show" syncable="YES"/>
+    </entity>
+    <entity name="EditionSet" representedClassName="EditionSet" syncable="YES">
+        <attribute name="artistProofs" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="availability" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="availableEditions" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="backendPrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="depth" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="diameter" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="dimensionsCM" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dimensionsInches" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="displayPrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="duration" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="editions" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="editionSize" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="height" optional="YES" attributeType="Decimal" defaultValueString="0" syncable="YES"/>
+        <attribute name="isAvailableForSale" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="isPriceHidden" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="prototypes" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="width" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <relationship name="artwork" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artwork" inverseName="editionSets" inverseEntity="Artwork" syncable="YES"/>
+    </entity>
+    <entity name="Image" representedClassName="Image" syncable="YES">
+        <attribute name="aspectRatio" optional="YES" attributeType="Float" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="baseURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isMainImage" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="maxTiledHeight" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="maxTiledWidth" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="originalHeight" optional="YES" attributeType="Float" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="originalWidth" optional="YES" attributeType="Float" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="position" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="processing" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="slug" attributeType="String" defaultValueString="unknown-image" syncable="YES"/>
+        <attribute name="tileBaseUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tileFormat" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tileOverlap" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="tileSize" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <relationship name="artistsInImage" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="installShotsFeaturingArtist" inverseEntity="Artist" syncable="YES"/>
+        <relationship name="artwork" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Artwork" inverseName="images" inverseEntity="Artwork" syncable="YES"/>
+        <relationship name="artworksInImage" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artwork" inverseName="installShotsFeaturingArtwork" inverseEntity="Artwork" syncable="YES"/>
+        <relationship name="coverForAlbum" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Album" inverseName="cover" inverseEntity="Album" syncable="YES"/>
+        <relationship name="coverForArtist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="cover" inverseEntity="Artist" syncable="YES"/>
+        <relationship name="coverForShow" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Show" inverseName="cover" inverseEntity="Show" syncable="YES"/>
+        <relationship name="mainImageForArtwork" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Artwork" inverseName="mainImage" inverseEntity="Artwork" syncable="YES"/>
+    </entity>
+    <entity name="InstallShotImage" representedClassName="InstallShotImage" parentEntity="Image" syncable="YES">
+        <attribute name="caption" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="showWithImageInInstallation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Show" inverseName="installationImages" inverseEntity="Show" syncable="YES"/>
+    </entity>
+    <entity name="LocalImage" representedClassName="LocalImage" parentEntity="Image" syncable="YES"/>
+    <entity name="Location" representedClassName="Location" syncable="YES">
+        <attribute name="address" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="addressSecond" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="city" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="geoPoint" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="phone" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="postalCode" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="slug" attributeType="String" defaultValueString="unknown-slug" syncable="YES"/>
+        <attribute name="state" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="locations" inverseEntity="Artwork" syncable="YES"/>
+        <relationship name="shows" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Show" inverseName="location" inverseEntity="Show" syncable="YES"/>
+    </entity>
+    <entity name="Note" representedClassName="Note" syncable="YES">
+        <attribute name="body" attributeType="String" syncable="YES"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <relationship name="artwork" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Artwork" inverseName="notes" inverseEntity="Artwork" syncable="YES"/>
+    </entity>
+    <entity name="Partner" representedClassName="Partner">
+        <attribute name="active" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="artistDocumentsCount" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="artistsCount" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="artworksCount" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="contractType" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="defaultProfileID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="defaultProfilePublic" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="foundingPartner" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="hasDefaultProfile" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="hasFullProfile" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="partnerID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="partnerLimitedAccess" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="partnerType" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="region" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="relativeSize" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="representativeEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="showDocumentsCount" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subscriptionState" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="website" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="admin" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="adminForPartner" inverseEntity="User" syncable="YES"/>
+        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Artwork" inverseName="partner" inverseEntity="Artwork">
+            <userInfo/>
+        </relationship>
+        <relationship name="flags" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PartnerOption" inverseName="partner" inverseEntity="PartnerOption" syncable="YES"/>
+        <relationship name="subscriptionPlans" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SubscriptionPlan" inverseName="subscriptionForPartner" inverseEntity="SubscriptionPlan" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="PartnerOption" representedClassName="PartnerOption" syncable="YES">
+        <attribute name="key" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="value" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="partner" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Partner" inverseName="flags" inverseEntity="Partner" syncable="YES"/>
+    </entity>
+    <entity name="Show" representedClassName="Show" syncable="YES">
+        <attribute name="availabilityPeriod" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="createdAt" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="endsAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="showSlug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="slug" attributeType="String" defaultValueString="unknown-slug" syncable="YES"/>
+        <attribute name="sortKey" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="startsAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="status" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <relationship name="artists" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artist" inverseName="showsFeaturingArtist" inverseEntity="Artist" syncable="YES"/>
+        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="shows" inverseEntity="Artwork" syncable="YES"/>
+        <relationship name="cover" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Image" inverseName="coverForShow" inverseEntity="Image" syncable="YES"/>
+        <relationship name="documents" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Document" inverseName="show" inverseEntity="Document" syncable="YES"/>
+        <relationship name="installationImages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="InstallShotImage" inverseName="showWithImageInInstallation" inverseEntity="InstallShotImage" syncable="YES"/>
+        <relationship name="location" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Location" inverseName="shows" inverseEntity="Location" syncable="YES"/>
+    </entity>
+    <entity name="ShowDocument" representedClassName="ShowDocument" parentEntity="Document" syncable="YES"/>
+    <entity name="SubscriptionPlan" representedClassName="SubscriptionPlan" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="subscriptionForPartner" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Partner" inverseName="subscriptionPlans" inverseEntity="Partner" syncable="YES"/>
+    </entity>
+    <entity name="SyncError" representedClassName="SyncError" syncable="YES">
+        <attribute name="body" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="errorType" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="syncLog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SyncLog" inverseName="syncErrors" inverseEntity="SyncLog" syncable="YES"/>
+    </entity>
+    <entity name="SyncLog" representedClassName="SyncLog" syncable="YES">
+        <attribute name="albumsDelta" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="artworkDelta" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="dateStarted" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="estimatedDownload" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="showDelta" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="timeToCompletion" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="totalDownloaded" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <relationship name="syncErrors" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SyncError" inverseName="syncLog" inverseEntity="SyncError" syncable="YES"/>
+    </entity>
+    <entity name="User" representedClassName="User" syncable="YES">
+        <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" elementID="user_role" syncable="YES"/>
+        <relationship name="adminForPartner" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Partner" inverseName="admin" inverseEntity="Partner" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="Album" positionX="0" positionY="0" width="128" height="255"/>
+        <element name="Artist" positionX="0" positionY="0" width="128" height="405"/>
+        <element name="ArtistDocument" positionX="0" positionY="0" width="128" height="45"/>
+        <element name="Artwork" positionX="0" positionY="0" width="128" height="645"/>
+        <element name="Document" positionX="0" positionY="0" width="128" height="210"/>
+        <element name="EditionSet" positionX="27" positionY="162" width="128" height="330"/>
+        <element name="Image" positionX="0" positionY="0" width="128" height="360"/>
+        <element name="InstallShotImage" positionX="18" positionY="153" width="128" height="73"/>
+        <element name="LocalImage" positionX="18" positionY="162" width="128" height="45"/>
+        <element name="Location" positionX="0" positionY="0" width="128" height="210"/>
+        <element name="Note" positionX="0" positionY="0" width="128" height="105"/>
+        <element name="Partner" positionX="0" positionY="0" width="128" height="465"/>
+        <element name="PartnerOption" positionX="18" positionY="153" width="128" height="88"/>
+        <element name="Show" positionX="0" positionY="0" width="128" height="283"/>
+        <element name="ShowDocument" positionX="0" positionY="0" width="128" height="45"/>
+        <element name="SubscriptionPlan" positionX="27" positionY="162" width="128" height="73"/>
+        <element name="SyncError" positionX="9" positionY="153" width="128" height="88"/>
+        <element name="SyncLog" positionX="9" positionY="153" width="128" height="163"/>
+        <element name="User" positionX="0" positionY="0" width="128" height="120"/>
+    </elements>
+</model>


### PR DESCRIPTION
Currently the data migration tests are failing, so I need to sort out migration, as well as further adding tests. 

This is to address #174 - basically Gravity is now sending partner sizes as integers rather than strings, and we were looking for strings. Migration will mean that "1a" and "1b" will now all map to 1. 



