### PR TITLE
Add support for linking to Artsy on a public Artwork

### DIFF
--- a/ArtsyFolio Tests/Util/AREmailComposerTests.m
+++ b/ArtsyFolio Tests/Util/AREmailComposerTests.m
@@ -28,7 +28,8 @@ beforeEach(^{
     context = [CoreDataManager stubbedManagedObjectContext];
     composer = [[AREmailComposer alloc] init];
     defaults = [[ForgeriesUserDefaults alloc] init];
-    
+    defaults[@"ARPartnerID"] = @"my-partner";
+
     composer.defaults = (id)defaults;
     composer.options = settings;
 });
@@ -408,6 +409,14 @@ describe(@"email html", ^{
 
             NSString *body = composer.body;
             expect(body).to.contain(@"https://www.artsy.net/artwork/ThisShouldBeInHere");
+        });
+
+        it(@"it includes a utr with the partner name", ^{
+            artwork.isPublished = @(YES);
+            defaults[@"ARPartnerID"] = @"my-partner";
+
+            NSString *body = composer.body;
+            expect(body).to.contain(@"utr=folio&partner=my-partner");
         });
 
         it(@"only if the work is public", ^{

--- a/ArtsyFolio Tests/Util/AREmailComposerTests.m
+++ b/ArtsyFolio Tests/Util/AREmailComposerTests.m
@@ -385,6 +385,38 @@ describe(@"email html", ^{
         expect(body).to.contain(artwork2.displayPrice);
     });
 
+    describe(@"includes a link to artsy", ^{
+        __block Artwork *artwork;
+
+        beforeEach(^{
+            artwork = [Artwork objectInContext:context];
+            artwork.title = @"Artwork Name 2";
+            artwork.slug = @"ThisShouldBeInHere";
+            artwork.displayPrice = @"456456";
+
+            Image *mainImage = [ARModelFactory imageWithKnownRemoteResourcesInContext:context];
+            mainImage.isMainImage = @(YES);
+            mainImage.baseURL = @"http://static0.artsy.net/additional_images/1/";
+            artwork.mainImage = mainImage;
+
+            composer.artworks = @[ artwork ];
+            composer.options.priceType = AREmailSettingsPriceTypeBackend;
+        });
+
+        it(@"if the work is public", ^{
+            artwork.isPublished = @(YES);
+
+            NSString *body = composer.body;
+            expect(body).to.contain(@"https://www.artsy.net/artwork/ThisShouldBeInHere");
+        });
+
+        it(@"only if the work is public", ^{
+            artwork.isPublished = @(NO);
+
+            NSString *body = composer.body;
+            expect(body).toNot.contain(@"https://www.artsy.net/artwork/ThisShouldBeInHere");
+        });
+    });
 });
 
 SpecEnd

--- a/Classes/Categories/UIDevice+Testing.m
+++ b/Classes/Categories/UIDevice+Testing.m
@@ -3,20 +3,9 @@
 
 @implementation UIDevice (Testing)
 
-// Thanks https://github.com/pietbrauer
-
-static BOOL ARRunningUnitTests = NO;
-
 + (BOOL)isRunningUnitTests
 {
-    static dispatch_once_t oncePredicate;
-    dispatch_once(&oncePredicate, ^{
-        NSString *XCInjectBundle = [[[NSProcessInfo processInfo] environment] objectForKey:@"XCInjectBundle"];
-
-        ARRunningUnitTests = [XCInjectBundle hasSuffix:@".xctest"];
-    });
-
-    return ARRunningUnitTests;
+    return NSClassFromString(@"XCTestCase") != nil;
 }
 
 @end

--- a/Classes/Models/Partner.h
+++ b/Classes/Models/Partner.h
@@ -18,6 +18,9 @@ typedef NS_ENUM(NSInteger, ARPartnerType) {
 /// Thread-safe current partner ID
 + (NSString *)currentPartnerID;
 
+/// Thread-safe current partner ID with a DI'd user defaults
++ (NSString *)currentPartnerIDInDefaults:(NSUserDefaults *)defaults;
+
 /// Has the partner uploaded any works?
 - (BOOL)hasUploadedWorks;
 

--- a/Classes/Models/Partner.m
+++ b/Classes/Models/Partner.m
@@ -8,7 +8,13 @@
 
 + (NSString *)currentPartnerID
 {
-    return [[NSUserDefaults standardUserDefaults] stringForKey:ARPartnerID];
+    return [self currentPartnerIDInDefaults:[NSUserDefaults standardUserDefaults]];
+}
+
++ (NSString *)currentPartnerIDInDefaults:(NSUserDefaults *)defaults
+{
+    return [defaults stringForKey:ARPartnerID];
+
 }
 
 - (void)updateWithDictionary:(NSDictionary *)dict

--- a/Classes/Util/App/CoreDataManager.m
+++ b/Classes/Util/App/CoreDataManager.m
@@ -113,7 +113,7 @@ static const NSString *ThreadContextKey = @"ThreadContextKey";
     if (ARIsOSSBuild) {
         storeURL = [[NSBundle mainBundle] URLForResource:@"oss_stubbed_data" withExtension:@"sqlite"];
     }
-    
+
     NSDictionary *options = @{ NSMigratePersistentStoresAutomaticallyOption : @(YES),
                                NSInferMappingModelAutomaticallyOption : @(YES) };
 
@@ -140,7 +140,7 @@ static const NSString *ThreadContextKey = @"ThreadContextKey";
 
     NSError *error = nil;
     NSManagedObjectModel *model = [CoreDataManager managedObjectModel];
-    persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:model];
+    NSPersistentStoreCoordinator *persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:model];
     if (![persistentStoreCoordinator addPersistentStoreWithType:NSInMemoryStoreType
                                                   configuration:nil
                                                             URL:nil

--- a/Classes/Util/Emails/AREmailComposer.m
+++ b/Classes/Util/Emails/AREmailComposer.m
@@ -117,7 +117,7 @@
     NSDictionary *properties = @{
         @"artworks" : @(self.artworks.count),
         @"price" : @(self.options.priceType > 0),
-        @"using_Exact_pricing" : @(self.options.priceType == AREmailSettingsPriceTypeBackend),
+        @"using_exact_pricing" : @(self.options.priceType == AREmailSettingsPriceTypeBackend),
         @"additional_images" : @(self.options.additionalImages.count),
         @"installation_shots" : @(self.options.installationShots.count),
         @"documents" : @(self.documents.count),

--- a/Classes/Util/Emails/AREmailComposer.m
+++ b/Classes/Util/Emails/AREmailComposer.m
@@ -168,7 +168,8 @@
         AREmailGreeting : greeting ?: @"",
         @"artworks" : artworkDicts,
         @"options" : self.options,
-        @"installation_shots" : installationShowAddresses ?: @[]
+        @"installation_shots" : installationShowAddresses ?: @[],
+        @"partner" : [Partner  currentPartnerIDInDefaults:self.defaults],
     };
 
     GRMustacheConfiguration *configuration = [GRMustacheConfiguration defaultConfiguration];

--- a/Resources/email_artwork_template.html
+++ b/Resources/email_artwork_template.html
@@ -81,7 +81,7 @@
                     {{/artwork.inventoryID}}{{/options.showInventoryID}}
 
                     {{#artwork.isPublished}}
-                    <p style="font-family: Georgia,serif; font-weight:100;margin-bottom:0px;margin-top:0px;">See on <a href="https://www.artsy.net/artwork/{{{artwork.slug}}}">Artsy.</a></p>
+                    <p style="font-family: Georgia,serif; font-weight:100;margin-bottom:0px;margin-top:0px;">See on <a href="https://www.artsy.net/artwork/{{{artwork.slug}}}?utr=folio&partner={{{partner}}}">Artsy.</a></p>
                     {{/artwork.isPublished}}
                 </div>
 

--- a/Resources/email_artwork_template.html
+++ b/Resources/email_artwork_template.html
@@ -77,9 +77,12 @@
                     {{/artwork.signature}}{{/options.showSupplementaryInformation}}
 
                     {{#options.showInventoryID}}{{#artwork.inventoryID}}
-                        <p style="font-family: Georgia,serif; font-weight:100;margin-bottom:0px;margin-top:0px;">{{{artwork.inventoryID}}}</p>
+                    <p style="font-family: Georgia,serif; font-weight:100;margin-bottom:0px;margin-top:0px;">{{{artwork.inventoryID}}}</p>
                     {{/artwork.inventoryID}}{{/options.showInventoryID}}
 
+                    {{#artwork.isPublished}}
+                    <p style="font-family: Georgia,serif; font-weight:100;margin-bottom:0px;margin-top:0px;">See on <a href="https://www.artsy.net/artwork/{{{artwork.slug}}}">Artsy.</a></p>
+                    {{/artwork.isPublished}}
                 </div>
 
                 {{#options.showSupplementaryInformation}}

--- a/docs/CHANGELOG.yml
+++ b/docs/CHANGELOG.yml
@@ -3,6 +3,7 @@ upcoming:
     notes:
       - Improved sync timing algorithm by weighing it towards the timing of the last sync [orta]
       - Partner Size now is a number, not a string [orta]
+      - Show a link to Artsy when a work is published in emails [orta]
 
 releases:
   - version: 2.5.0


### PR DESCRIPTION
https://github.com/artsy/energy/issues/181 

Now at the end of the artwork section of an email, there is a "Open on Artsy." - with "Artsy" being clickable and will take you directly to the artwork.