### PR TITLE
Remove the size to fit on select buttons for selections on iPhone

### DIFF
--- a/Classes/Controllers/Collections Controllers/Hosts/ARHostSelectionController.m
+++ b/Classes/Controllers/Collections Controllers/Hosts/ARHostSelectionController.m
@@ -161,7 +161,6 @@
     }
 
     [selectAllButton setTitle:selectAllText forState:UIControlStateNormal];
-    [selectAllButton sizeToFit];
     [self updateTitleWithCount:selectedObjects.count];
 }
 


### PR DESCRIPTION
Fixes #180

This bug is new to iOS9, what I think changed is that `sizeToFit` on a button now does not perform a layout pass, meaning AL won't override the size to be the one you have constrained, but instead will set the size of the view to the `sizeToFit` size. 

I expect the size to fit was needed in older versions, but runs fine in iOS8 👍 