### PR TITLE
Multi Artist Support for Artworks

### DIFF
--- a/Artsy Folio.xcodeproj/project.pbxproj
+++ b/Artsy Folio.xcodeproj/project.pbxproj
@@ -1256,6 +1256,7 @@
 		60D211101AE1721900EA091C /* ARArtworkContainerCoverDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARArtworkContainerCoverDataSource.h; sourceTree = "<group>"; };
 		60D211111AE1721900EA091C /* ARArtworkContainerCoverDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARArtworkContainerCoverDataSource.m; sourceTree = "<group>"; };
 		60D264A715E78AC1001A192D /* ARArtworkContainer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARArtworkContainer.h; sourceTree = "<group>"; };
+		60D39AE41CD39AEB00719AEE /* ArtsyFolio v2.5.1.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "ArtsyFolio v2.5.1.xcdatamodel"; sourceTree = "<group>"; };
 		60D46F5618E0CC4C00DA225B /* ARSyncDeleterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARSyncDeleterTests.m; sourceTree = "<group>"; };
 		60D4D719198FD558001AB8AF /* ARAppDelegate+DevTools.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "ARAppDelegate+DevTools.h"; path = "../ARAppDelegate+DevTools.h"; sourceTree = "<group>"; };
 		60D4D71A198FD558001AB8AF /* ARAppDelegate+DevTools.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "ARAppDelegate+DevTools.m"; path = "../ARAppDelegate+DevTools.m"; sourceTree = "<group>"; };
@@ -4678,6 +4679,7 @@
 		60118682174D084700B878A1 /* ArtsyPartner.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				60D39AE41CD39AEB00719AEE /* ArtsyFolio v2.5.1.xcdatamodel */,
 				60C939331C7D39DA0010136C /* ArtsyFolio v2.5.xcdatamodel */,
 				839B59751B4D955900F24033 /* ArtsyFolio v2.4.xcdatamodel */,
 				8343B7BC1B4C5667005790A9 /* ArtsyFolio v2.3.xcdatamodel */,
@@ -4693,7 +4695,7 @@
 				60118687174D084700B878A1 /* ArtsyPartner 5.xcdatamodel */,
 				60118688174D084700B878A1 /* ArtsyPartner.xcdatamodel */,
 			);
-			currentVersion = 60C939331C7D39DA0010136C /* ArtsyFolio v2.5.xcdatamodel */;
+			currentVersion = 60D39AE41CD39AEB00719AEE /* ArtsyFolio v2.5.1.xcdatamodel */;
 			path = ArtsyPartner.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/ArtsyFolio Tests/Migrations/ARAppDataMigrationsTest.m
+++ b/ArtsyFolio Tests/Migrations/ARAppDataMigrationsTest.m
@@ -59,7 +59,7 @@ SpecEnd
     // Set the persistent store to be the fixture data
     if (![persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:storeURL options:options error:&error]) {
         NSLog(@"Error creating persistant store: %@", error.localizedDescription);
-        @throw @"Bad store";
+        @throw @"Bad persistant store, e.g. fixture data?";
         return nil;
     }
 

--- a/ArtsyFolio Tests/Models/ArtworkModelTests.m
+++ b/ArtsyFolio Tests/Models/ArtworkModelTests.m
@@ -9,18 +9,18 @@ describe(@"json parsing", ^{
         context = [CoreDataManager stubbedManagedObjectContext];
 
         artwork1 = [Artwork modelFromJSON:@{
-                   ARFeedDepthKey : @"",
-                   ARFeedHeightKey : @"23",
-                   ARFeedWidthKey : [NSNull null],
-                   ARFeedDiameterKey : @"42",
-                   ARFeedMetricKey : @"in",
-                   } inContext:context];
-        
+            ARFeedDepthKey : @"",
+            ARFeedHeightKey : @"23",
+            ARFeedWidthKey : [NSNull null],
+            ARFeedDiameterKey : @"42",
+            ARFeedMetricKey : @"in",
+        } inContext:context];
+
         artwork2 = [Artwork modelFromJSON:@{
-                    ARFeedMetricKey : @"cm",
-                    ARFeedWidthKey : @"22",
-                    ARFeedDepthKey : @"",
-                    } inContext:context];
+            ARFeedMetricKey : @"cm",
+            ARFeedWidthKey : @"22",
+            ARFeedDepthKey : @"",
+        } inContext:context];
     });
 
 
@@ -35,17 +35,42 @@ describe(@"json parsing", ^{
     it(@"correctly converts decimals from nulls", ^{
         expect(artwork1.width).to.beNil;
     });
-    
+
     it(@"does not convert dimensions if using american units", ^{
         expect(artwork1.diameter).to.equal([NSDecimalNumber decimalNumberWithString:@"42"]);
     });
-    
+
     it(@"does convert dimensions if using metric system", ^{
-        NSNumber *value = @(22/2.54);
+        NSNumber *value = @(22 / 2.54);
         NSDecimalNumber *convertedWidth = [NSDecimalNumber decimalNumberWithString:[NSString stringWithFormat:@"%@", value]];
         expect(artwork2.width).to.equal(convertedWidth);
     });
 
+    describe(@"artist display string", ^{
+        it(@"supports the old style 'artist'", ^{
+            Artwork *artwork = [Artwork modelFromJSON:@{
+                @"id" : @"ok",
+                @"artist" : @{@"name" : @"one"},
+            } inContext:context];
+            expect(artwork.artistDisplayString).to.equal(@"one");
+        });
+
+        it(@"supports multiple artists", ^{
+            Artwork *artwork = [Artwork modelFromJSON:@{
+                @"id" : @"ok",
+                @"artists" : @[ @{@"name" : @"one"}, @{@"name" : @"two"} ]
+            } inContext:context];
+            expect(artwork.artistDisplayString).to.equal(@"one, two");
+        });
+    });
+
+    it(@"correctly handles multiple artists", ^{
+        Artwork *artwork = [Artwork modelFromJSON:@{
+            @"id" : @"ok",
+            @"artists" : @[ @{@"id" : @"one"}, @{@"id" : @"two"} ]
+        } inContext:context];
+        expect(artwork.artists.count).to.equal(2);
+    });
 });
 
 SpecEnd

--- a/ArtsyFolio Tests/Models/ArtworkModelTests.m
+++ b/ArtsyFolio Tests/Models/ArtworkModelTests.m
@@ -50,7 +50,7 @@ describe(@"json parsing", ^{
         it(@"supports the old style 'artist'", ^{
             Artwork *artwork = [Artwork modelFromJSON:@{
                 @"id" : @"ok",
-                @"artist" : @{@"name" : @"one"},
+                @"artists" : @[ @{@"id" : @"id1", @"name" : @"one"} ],
             } inContext:context];
             expect(artwork.artistDisplayString).to.equal(@"one");
         });
@@ -58,9 +58,10 @@ describe(@"json parsing", ^{
         it(@"supports multiple artists", ^{
             Artwork *artwork = [Artwork modelFromJSON:@{
                 @"id" : @"ok",
-                @"artists" : @[ @{@"name" : @"one"}, @{@"name" : @"two"} ]
+                @"artists" : @[ @{@"id" : @"id1", @"name" : @"anna", @"sortable_id" : @"anna"}, @{@"id" : @"id2", @"name" : @"brianna", @"sortable_id" : @"brianna"} ]
             } inContext:context];
-            expect(artwork.artistDisplayString).to.equal(@"one, two");
+            // It's alphabetically ordered
+            expect(artwork.artistDisplayString).to.contain(@"anna, brianna");
         });
     });
 

--- a/ArtsyFolio Tests/Models/NSFetchRequest+ARModelsTests.m
+++ b/ArtsyFolio Tests/Models/NSFetchRequest+ARModelsTests.m
@@ -14,7 +14,7 @@ beforeEach(^{
     context = [CoreDataManager stubbedManagedObjectContext];
     defaults = [[ForgeriesUserDefaults alloc] init];
 
-    artist1  = [Artist stubbedArtistWithPublishedArtworks:YES inContext:context];
+    artist1 = [Artist stubbedArtistWithPublishedArtworks:YES inContext:context];
     artist2 = [Artist stubbedArtistWithPublishedArtworks:YES inContext:context];
     artist3 = [Artist stubbedArtistWithPublishedArtworks:NO inContext:context];
 });
@@ -24,9 +24,9 @@ describe(@"all instances of a container", ^{
 
     it(@"returns all objects of a class", ^{
         Class klass = Artist.class;
-       request = [NSFetchRequest ar_allInstancesOfArtworkContainerClass:klass
-                                                              inContext:context
-                                                               defaults:(id)defaults];
+        request = [NSFetchRequest ar_allInstancesOfArtworkContainerClass:klass
+                                                               inContext:context
+                                                                defaults:(id)defaults];
         NSArray *results = [context executeFetchRequest:request error:nil];
         expect(results).to.contain(artist1);
         expect(results).to.contain(artist2);
@@ -46,10 +46,10 @@ describe(@"all instances of a container", ^{
     it(@"respects the hide unavailable default in presentation mode", ^{
         defaults[ARPresentationModeOn] = @(YES);
         defaults[ARHideWorksNotForSale] = @(YES);
-        
+
         Artwork *artwork = artist1.artworks.firstObject;
         artwork.isAvailableForSale = @(YES);
-        
+
         request = [NSFetchRequest ar_allInstancesOfArtworkContainerClass:Artist.class
                                                                inContext:context
                                                                 defaults:(id)defaults];
@@ -58,7 +58,7 @@ describe(@"all instances of a container", ^{
         expect(results).toNot.contain(artist2);
         expect(results.count).to.equal(1);
     });
-    
+
     it(@"respects the hide unpublished default in presentation mode", ^{
         defaults[ARPresentationModeOn] = @(YES);
         defaults[ARHideUnpublishedWorks] = @(YES);
@@ -74,10 +74,10 @@ describe(@"all instances of a container", ^{
     it(@"ignores the hide unavailable default when not in presentation mode", ^{
         defaults[ARPresentationModeOn] = @(NO);
         defaults[ARHideWorksNotForSale] = @(YES);
-        
+
         Artwork *artwork = artist1.artworks.firstObject;
         artwork.isAvailableForSale = @(YES);
-        
+
         request = [NSFetchRequest ar_allInstancesOfArtworkContainerClass:Artist.class
                                                                inContext:context
                                                                 defaults:(id)defaults];
@@ -86,7 +86,7 @@ describe(@"all instances of a container", ^{
         expect(results).to.contain(artist2);
         expect(results.count).to.equal(3);
     });
-    
+
     it(@"ignores the hide unpublished default when not in presentation mode", ^{
         defaults[ARPresentationModeOn] = @(NO);
         defaults[ARHideUnpublishedWorks] = @(YES);
@@ -111,7 +111,7 @@ describe(@"all artworks from a container", ^{
         artwork3 = [Artwork stubbedArtworkWithImages:YES inContext:context];
         artist1.artworks = [NSSet setWithObjects:artwork1, artwork2, artwork3, nil];
         artist1.slug = @"danger";
-        scopePredicate = [NSPredicate predicateWithFormat:@"artist.slug == %@", artist1.slug];
+        scopePredicate = [NSPredicate predicateWithFormat:@"ANY artists.slug == %@", artist1.slug];
     });
 
     it(@"returns all artworks for an instance", ^{
@@ -146,10 +146,10 @@ describe(@"all artworks from a container", ^{
     it(@"respects the hide unavailable default in presentation mode", ^{
         defaults[ARPresentationModeOn] = @(YES);
         defaults[ARHideWorksNotForSale] = @(YES);
-        
+
         artwork1.isAvailableForSale = @(YES);
         request = [NSFetchRequest ar_allArtworksOfArtworkContainerWithSelfPredicate:scopePredicate inContext:context defaults:(id)defaults];
-        
+
         NSArray *results = [context executeFetchRequest:request error:nil];
         expect(results).to.contain(artwork1);
         expect(results.count).to.equal(1);
@@ -159,43 +159,43 @@ describe(@"all artworks from a container", ^{
     it(@"ignores the hide unavailable default when not in presentation mode", ^{
         defaults[ARPresentationModeOn] = @(NO);
         defaults[ARHideWorksNotForSale] = @(YES);
-        
+
         artwork1.isAvailableForSale = @(YES);
         request = [NSFetchRequest ar_allArtworksOfArtworkContainerWithSelfPredicate:scopePredicate inContext:context defaults:(id)defaults];
-        
-        NSArray *results = [context executeFetchRequest:request error:nil];
-        expect(results).to.contain(artwork1);
-        expect(results).to.contain(artwork2);
-        expect(results.count).to.equal(3);
-    });
-    
-    it(@"respects the hide unpublished default in presentation mode", ^{
-        defaults[ARPresentationModeOn] = @(YES);
-        defaults[ARHideUnpublishedWorks] = @(YES);
-        
-        artwork1.isPublished = @(YES);
-        request = [NSFetchRequest ar_allArtworksOfArtworkContainerWithSelfPredicate:scopePredicate inContext:context defaults:(id)defaults];
-        
-        NSArray *results = [context executeFetchRequest:request error:nil];
-        expect(results).to.contain(artwork1);
-        expect(results.count).to.equal(1);
-        expect(results).toNot.contain(artwork2);
-    });
-    
-    it(@"ignores the hide unpublished default when not in presentation mode", ^{
-        defaults[ARPresentationModeOn] = @(NO);
-        defaults[ARHideWorksNotForSale] = @(YES);
-        
-        artwork1.isPublished = @(YES);
-        request = [NSFetchRequest ar_allArtworksOfArtworkContainerWithSelfPredicate:scopePredicate inContext:context defaults:(id)defaults];
-        
+
         NSArray *results = [context executeFetchRequest:request error:nil];
         expect(results).to.contain(artwork1);
         expect(results).to.contain(artwork2);
         expect(results.count).to.equal(3);
     });
 
-    
+    it(@"respects the hide unpublished default in presentation mode", ^{
+        defaults[ARPresentationModeOn] = @(YES);
+        defaults[ARHideUnpublishedWorks] = @(YES);
+
+        artwork1.isPublished = @(YES);
+        request = [NSFetchRequest ar_allArtworksOfArtworkContainerWithSelfPredicate:scopePredicate inContext:context defaults:(id)defaults];
+
+        NSArray *results = [context executeFetchRequest:request error:nil];
+        expect(results).to.contain(artwork1);
+        expect(results.count).to.equal(1);
+        expect(results).toNot.contain(artwork2);
+    });
+
+    it(@"ignores the hide unpublished default when not in presentation mode", ^{
+        defaults[ARPresentationModeOn] = @(NO);
+        defaults[ARHideWorksNotForSale] = @(YES);
+
+        artwork1.isPublished = @(YES);
+        request = [NSFetchRequest ar_allArtworksOfArtworkContainerWithSelfPredicate:scopePredicate inContext:context defaults:(id)defaults];
+
+        NSArray *results = [context executeFetchRequest:request error:nil];
+        expect(results).to.contain(artwork1);
+        expect(results).to.contain(artwork2);
+        expect(results.count).to.equal(3);
+    });
+
+
     pending(@"respects the hide unpublished default", ^{
         defaults[ARHideUnpublishedWorks] = @(YES);
         artwork1.isPublished = @(NO);

--- a/ArtsyFolio Tests/Models/PartnerModelTests.m
+++ b/ArtsyFolio Tests/Models/PartnerModelTests.m
@@ -27,7 +27,7 @@ describe(@"has uploaded works on cms", ^{
     });
 
     it(@"also takes into account the amount of artworks in the MOC", ^{
-        Artwork *artwork = [Artwork objectInContext:context];
+        [Artwork objectInContext:context];
         partner.artworksCount = @(0);
 
         expect(partner.hasUploadedWorks).to.beTruthy();
@@ -44,7 +44,7 @@ describe(@"partner type", ^{
         partner = [Partner modelFromJSON:@{ @"type" : @"Anything" } inContext:context];
         expect(partner.type).to.equal(ARPartnerTypeGallery);
 
-        partner = [Partner modelFromJSON:@{ } inContext:context];
+        partner = [Partner modelFromJSON:@{} inContext:context];
         expect(partner.type).to.equal(ARPartnerTypeGallery);
     });
 });
@@ -82,49 +82,49 @@ describe(@"available artwork type checks", ^{
             expect(partner.hasPublishedWorks).to.beFalsy();
         });
     });
-    
+
     describe(@"sold works", ^{
         it(@"returns true when the core data db has sold works", ^{
             Artwork *artwork = [Artwork objectInContext:context];
             artwork.availability = @"sold";
-            
+
             expect(partner.hasSoldWorks).to.beTruthy();
         });
-        
+
         it(@"returns false when the core data db has no sold works", ^{
             Artwork *artwork = [Artwork objectInContext:context];
             artwork.availability = @"on hold";
-            
+
             expect(partner.hasSoldWorks).to.beFalsy();
         });
-        
+
         it(@"returns true when the core data db has sold works with prices", ^{
             Artwork *artwork0 = [Artwork objectInContext:context];
             artwork0.availability = @"sold";
             artwork0.displayPrice = @"200";
-            
+
             expect(partner.hasSoldWorksWithPrices).to.beTruthy();
         });
-        
+
         it(@"returns false when the core data db has sold works without prices only", ^{
             Artwork *artwork = [Artwork objectInContext:context];
             artwork.availability = @"sold";
             artwork.displayPrice = @"";
             artwork.backendPrice = @"";
-            
+
             expect(partner.hasSoldWorksWithPrices).to.beFalsy();
         });
-        
+
         it(@"returns false when the core data db has sold works without prices only and for sale works with prices", ^{
             Artwork *artwork0 = [Artwork objectInContext:context];
             artwork0.availability = @"sold";
             artwork0.displayPrice = @"";
             artwork0.backendPrice = @"";
-            
+
             Artwork *artwork1 = [Artwork objectInContext:context];
             artwork1.availability = @"for sale";
             artwork1.displayPrice = @"300";
-            
+
             expect(partner.hasSoldWorksWithPrices).to.beFalsy();
         });
     });
@@ -152,19 +152,19 @@ describe(@"available artwork type checks", ^{
             expect(partner.hasPublishedWorks).to.beFalsy();
         });
     });
-    
+
     describe(@"for works with confidential notes", ^{
         it(@"returns true when partner has works with conf. notes", ^{
             Artwork *artwork = [Artwork objectInContext:context];
             artwork.confidentialNotes = @"super secret";
-            
+
             expect(partner.hasConfidentialNotes).to.beTruthy();
         });
-        
+
         it(@"returns false when partner has no works with conf. notes", ^{
             Artwork *artwork = [Artwork objectInContext:context];
             artwork.confidentialNotes = @"";
-            
+
             expect(partner.hasConfidentialNotes).to.beFalsy();
         });
     });

--- a/ArtsyFolio Tests/Sync/ARSlugResolverTests.m
+++ b/ArtsyFolio Tests/Sync/ARSlugResolverTests.m
@@ -25,14 +25,14 @@ describe(@"resolving albums", ^{
 
         artwork1 = [Artwork stubbedArtworkWithImages:YES inContext:context];
         artwork1.slug = slugs[0];
-        artwork1.artist = artist;
+        artwork1.artists = [NSSet setWithObject:artist];
 
         artwork2 = [Artwork stubbedArtworkWithImages:YES inContext:context];
         artwork2.slug = slugs[1];
-        artwork2.artist = artist;
+        artwork2.artists = [NSSet setWithObject:artist];
 
         artwork3 = [Artwork stubbedArtworkWithImages:YES inContext:context];
-        artwork3.artist = artist;
+        artwork3.artists = [NSSet setWithObject:artist];
 
         downloadedAlbum = [Album objectInContext:context];
         downloadedAlbum.artworkSlugs = [NSSet setWithArray:slugs];
@@ -117,14 +117,14 @@ describe(@"resolving shows", ^{
 
         Artwork *artwork = [Artwork stubbedArtworkWithImages:YES inContext:context];
         artwork.slug = slugs[0];
-        artwork.artist = artist;
+        artwork.artists = [NSSet setWithObject:artist];
 
         Artwork *artwork2 = [Artwork stubbedArtworkWithImages:YES inContext:context];
         artwork2.slug = slugs[1];
-        artwork2.artist = artist;
+        artwork2.artists = [NSSet setWithObject:artist];
 
         Artwork *artwork3 = [Artwork stubbedArtworkWithImages:YES inContext:context];
-        artwork3.artist = artist;
+        artwork3.artists = [NSSet setWithObject:artist];
 
         Show *show = [Show objectInContext:context];
         show.artworkSlugs = [NSSet setWithArray:slugs];

--- a/ArtsyFolio Tests/Sync/ARSlugResolverTests.m
+++ b/ArtsyFolio Tests/Sync/ARSlugResolverTests.m
@@ -17,12 +17,10 @@ describe(@"resolving albums", ^{
     __block NSInteger preAlbumCount;
     __block NSArray *allAlbums;
 
-    __block ARSync *sync;
-    
     beforeAll(^{
         context = [CoreDataManager stubbedManagedObjectContext];
         artist = [Artist objectInContext:context];
-        NSArray *slugs = @[@"slug1", @"slug2"];
+        NSArray *slugs = @[ @"slug1", @"slug2" ];
         partner = [Partner createInContext:context];
 
         artwork1 = [Artwork stubbedArtworkWithImages:YES inContext:context];
@@ -45,18 +43,18 @@ describe(@"resolving albums", ^{
         localAlbum.editable = @(YES);
 
         localFilledAlbum = [Album objectInContext:context];
-        localFilledAlbum.artworks = [NSSet setWithArray:@[artwork1]];
+        localFilledAlbum.artworks = [NSSet setWithArray:@[ artwork1 ]];
         localFilledAlbum.editable = @(YES);
 
         preAlbumCount = [Album countInContext:context error:nil];
-        
+
         ARSlugResolver *resolver = [[ARSlugResolver alloc] init];
 
         ARSync *sync = [ARSync syncForTesting:context];
         [resolver syncDidFinish:sync];
-        
+
         allAlbums = [Album findAllInContext:context];
-        
+
     });
 
     it(@"sets artworks from slugs", ^{
@@ -68,22 +66,22 @@ describe(@"resolving albums", ^{
     it(@"does not set the artworks for local albums", ^{
         expect(localAlbum.artworks.count).to.equal(0);
     });
-    
+
     it(@"creates an all artworks album", ^{
         NSInteger postAlbumCount = [Album countInContext:context error:nil];
         expect(preAlbumCount).to.beLessThan(postAlbumCount);
     });
-    
+
     it(@"contains an all artworks album", ^{
         Album *allArtworksAlbum = [Album findFirstByAttribute:@"slug" withValue:@"all_artworks" inContext:context];
         expect(allArtworksAlbum).to.beTruthy();
     });
-    
+
     it(@"does not create a for sale album if there are no for sale artworks", ^{
         Album *forSaleAlbum = [Album findFirstByAttribute:@"slug" withValue:@"for_sale_works" inContext:context];
         expect(forSaleAlbum).to.beFalsy();
     });
-    
+
     it(@"contains a for sale album with only for sale artworks", ^{
         artwork2.isAvailableForSale = @YES;
 
@@ -114,7 +112,7 @@ describe(@"resolving albums", ^{
 describe(@"resolving shows", ^{
     it(@"sets artworks from slugs", ^{
         NSManagedObjectContext *context = [CoreDataManager stubbedManagedObjectContext];
-        NSArray *slugs = @[@"slug1", @"slug2"];
+        NSArray *slugs = @[ @"slug1", @"slug2" ];
         Artist *artist = [Artist objectInContext:context];
 
         Artwork *artwork = [Artwork stubbedArtworkWithImages:YES inContext:context];
@@ -146,7 +144,7 @@ describe(@"resolving shows", ^{
 describe(@"resolving locations", ^{
     it(@"sets artworks from slugs", ^{
         NSManagedObjectContext *context = [CoreDataManager stubbedManagedObjectContext];
-        NSArray *slugs = @[@"slug1", @"slug2"];
+        NSArray *slugs = @[ @"slug1", @"slug2" ];
 
         Artwork *artwork = [Artwork stubbedArtworkWithImages:YES inContext:context];
         artwork.slug = slugs[0];

--- a/ArtsyFolio Tests/Sync/ARSyncDeleterTests.m
+++ b/ArtsyFolio Tests/Sync/ARSyncDeleterTests.m
@@ -63,7 +63,9 @@ describe(@"Removing objects", ^{
         [sut markObjectForDeletion:artwork];
         [sut deleteObjects];
 
-        [mock verify];
+        /// So, the delay is because the deletion is now happening
+        /// on whatever thread the NSManagedObjectContext wants.
+        [mock verifyWithDelay:0.1];
     });
 
 });

--- a/ArtsyFolio Tests/Sync/ARSyncProgressTests.m
+++ b/ArtsyFolio Tests/Sync/ARSyncProgressTests.m
@@ -11,16 +11,16 @@ before(^{
 describe(@"estimates", ^{
     it(@"it provides an estimate based on the bytes downloaded", ^{
         [sut startWithLastSyncLog:0];
-        sut.numEstimatedBytes = 100000;
-        [sut downloadedNumBytes:1];
+        sut.numEstimatedBytes = 1000000000;
+        [sut downloadedNumBytes:10000];
 
-        expect(sut.estimatedTimeRemaining).to.beInTheRangeOf(0, 5);
+        expect(sut.estimatedTimeRemaining).to.beLessThan(7);
     });
 
     it(@"it weighs the estimate based on a last sync time", ^{
         [sut startWithLastSyncLog:20];
-        sut.numEstimatedBytes = 10000;
-        [sut downloadedNumBytes:1];
+        sut.numEstimatedBytes = 1000000000;
+        [sut downloadedNumBytes:10000];
 
         expect(sut.estimatedTimeRemaining).to.beInTheRangeOf(9, 11);
     });

--- a/ArtsyFolio Tests/Sync/ARSyncProgressTests.m
+++ b/ArtsyFolio Tests/Sync/ARSyncProgressTests.m
@@ -22,7 +22,7 @@ describe(@"estimates", ^{
         sut.numEstimatedBytes = 1000000000;
         [sut downloadedNumBytes:10000];
 
-        expect(sut.estimatedTimeRemaining).to.beInTheRangeOf(9, 11);
+        expect(sut.estimatedTimeRemaining).to.beLessThan(12);
     });
 
 });

--- a/ArtsyFolio Tests/Testing Util Objects/ARStubbedCoreData.m
+++ b/ArtsyFolio Tests/Testing Util Objects/ARStubbedCoreData.m
@@ -27,7 +27,10 @@
     Artwork *artwork2 = [ARModelFactory partiallyFilledArtworkInContext:context];
     Artwork *artwork3 = [ARModelFactory partiallyFilledArtworkInContext:context];
 
-    instance.artist1.artworks = [NSSet setWithObjects:artwork1, artwork2, artwork3, nil];
+
+    for (Artwork *artwork in @[ artwork1, artwork2, artwork3 ]) {
+        artwork.artists = [NSSet setWithObject:instance.artist1];
+    }
     return instance;
 }
 

--- a/ArtsyFolio Tests/Testing Util Objects/ARTestContext.m
+++ b/ArtsyFolio Tests/Testing Util Objects/ARTestContext.m
@@ -1,3 +1,4 @@
+
 #import "ARTestContext.h"
 #import "UIDevice+DeviceInfo.h"
 #import "ARDispatchManager.h"
@@ -27,10 +28,13 @@ NS_ENUM(NSInteger, ARDeviceType){
     NSOperatingSystemVersion version = [NSProcessInfo processInfo].operatingSystemVersion;
     BOOL isRightVersion = version.majorVersion == osVersion && version.minorVersion == minorVersion;
 
-    NSAssert(isRightVersion, @"The tests should be run on iOS %ld.%ld, not %ld.%ld", osVersion, minorVersion, version.majorVersion, version.minorVersion);
+    if (!isRightVersion) {
+        @throw NSStringWithFormat(@"The tests should be run on iOS %@.%@, not %@.%@", @(osVersion), @(minorVersion), @(version.majorVersion), @(version.minorVersion));
+    }
 
-    CGSize nativeResolution = [UIScreen mainScreen].nativeBounds.size;
-    NSAssert([UIDevice isPad], @"The tests should be run on an iPad Retina");
+    if (![UIDevice isPad]) {
+        @throw @"The tests should be run on an iPad Retina";
+    }
 }
 
 

--- a/ArtsyFolio Tests/Util/AREmailComposerTests.m
+++ b/ArtsyFolio Tests/Util/AREmailComposerTests.m
@@ -55,7 +55,7 @@ describe(@"with 1 artwork", ^{
 
         artwork = [Artwork objectInContext:context];
         artwork.title = @"Artwork Name";
-        artwork.artist = artist;
+        artwork.artists = [NSSet setWithObject:artist];
         composer.artworks = @[ artwork ];
     });
 
@@ -81,7 +81,7 @@ describe(@"with 1 artwork", ^{
         NSString *subject = @"Check out %@ by %@";
         defaults[AREmailSubject] = subject;
         expect([composer subject]).to.contain(artwork.title);
-        expect([composer subject]).to.contain(artwork.artist.presentableName);
+        expect([composer subject]).to.contain(artwork.artists.anyObject.presentableName);
     });
 });
 
@@ -96,14 +96,14 @@ describe(@"with artworks > 1", ^{
 
             artwork = [Artwork objectInContext:context];
             artwork.title = @"Artwork Name";
-            artwork.artist = artist;
+            artwork.artists = [NSSet setWithObject:artist];
 
             artwork2 = [Artwork objectInContext:context];
             artwork2.title = @"Artwork2 Name";
-            artwork2.artist = artist;
+            artwork2.artists = [NSSet setWithObject:artist];
 
             untitledArtwork = [Artwork objectInContext:context];
-            untitledArtwork.artist = artist;
+            untitledArtwork.artists = [NSSet setWithObject:artist];
 
             composer.artworks = @[ artwork, artwork2 ];
         });
@@ -123,14 +123,14 @@ describe(@"with artworks > 1", ^{
         it(@"replaces one %@ with artist name", ^{
             NSString *subject = @"Check out %@";
             defaults[ARMultipleSameArtistEmailSubject] = subject;
-            expect([composer subject]).to.contain(artwork.artist.presentableName);
+            expect([composer subject]).to.contain(artwork.artistDisplayString);
         });
 
         it(@"replaces two %@s with nothing", ^{
             NSString *subject = @"Check out %@ by %@";
             defaults[ARMultipleSameArtistEmailSubject] = subject;
             expect([composer subject]).toNot.contain(artwork.title);
-            expect([composer subject]).toNot.contain(artwork.artist.presentableName);
+            expect([composer subject]).toNot.contain(artwork.artistDisplayString);
         });
 
         it(@"handles untitled artworks correctly ", ^{
@@ -154,11 +154,11 @@ describe(@"with artworks > 1", ^{
 
             artwork = [Artwork objectInContext:context];
             artwork.title = @"Artwork Name";
-            artwork.artist = artist;
+            artwork.artists = [NSSet setWithObject:artist];
 
             artwork2 = [Artwork objectInContext:context];
             artwork2.title = @"Artwork2 Name";
-            artwork2.artist = artist2;
+            artwork2.artists = [NSSet setWithObject:artist2];
 
             composer.artworks = @[ artwork, artwork2 ];
         });
@@ -230,7 +230,7 @@ describe(@"email html", ^{
     it(@"handles showing multiple artist names for an artwork", ^{
         artwork.artists = [NSSet setWithObjects:artist, artist2, nil];
         composer.artworks = @[ artwork ];
-        expect(composer.body).to.contain(artist.displayName);
+        expect(composer.body).to.contain(artwork.artistDisplayString);
     });
 
     it(@"converts newlines in signature to <br/>", ^{

--- a/ArtsyFolio Tests/Util/AREmailComposerTests.m
+++ b/ArtsyFolio Tests/Util/AREmailComposerTests.m
@@ -230,7 +230,7 @@ describe(@"email html", ^{
     it(@"handles showing multiple artist names for an artwork", ^{
         artwork.artists = [NSSet setWithObjects:artist, artist2, nil];
         composer.artworks = @[ artwork ];
-        expect(composer.body).to.contain(artwork.artistDisplayString);
+        expect(composer.body).to.contain(artwork.artistDisplayString.uppercaseString);
     });
 
     it(@"converts newlines in signature to <br/>", ^{

--- a/ArtsyFolio Tests/Util/AREmailComposerTests.m
+++ b/ArtsyFolio Tests/Util/AREmailComposerTests.m
@@ -36,13 +36,13 @@ beforeEach(^{
 
 describe(@"standard email settings", ^{
     it(@"generates one cc email address when only one is entered", ^{
-       defaults[AREmailCCEmail] = @"email@aol.com";
-        expect([composer generateCCEmails:defaults[AREmailCCEmail]]).to.equalArray(@[@"email@aol.com"]);
+        defaults[AREmailCCEmail] = @"email@aol.com";
+        expect([composer generateCCEmails:defaults[AREmailCCEmail]]).to.equalArray(@[ @"email@aol.com" ]);
     });
-    
+
     it(@"generates an array of cc email addresses when there are more than one", ^{
         defaults[AREmailCCEmail] = @"email1@aol.com,email2@aol.com";
-        expect([composer generateCCEmails:defaults[AREmailCCEmail]]).to.equalArray(@[@"email1@aol.com", @"email2@aol.com"]);
+        expect([composer generateCCEmails:defaults[AREmailCCEmail]]).to.equalArray(@[ @"email1@aol.com", @"email2@aol.com" ]);
     });
 });
 
@@ -101,10 +101,10 @@ describe(@"with artworks > 1", ^{
             artwork2 = [Artwork objectInContext:context];
             artwork2.title = @"Artwork2 Name";
             artwork2.artist = artist;
-            
+
             untitledArtwork = [Artwork objectInContext:context];
             untitledArtwork.artist = artist;
-            
+
             composer.artworks = @[ artwork, artwork2 ];
         });
 
@@ -132,10 +132,10 @@ describe(@"with artworks > 1", ^{
             expect([composer subject]).toNot.contain(artwork.title);
             expect([composer subject]).toNot.contain(artwork.artist.presentableName);
         });
-        
+
         it(@"handles untitled artworks correctly ", ^{
             defaults[AREmailSubject] = @"Check out %@ by %@";
-            
+
             composer.artworks = @[ untitledArtwork ];
             expect([composer subject]).toNot.contain(@"(null)");
         });
@@ -190,14 +190,17 @@ describe(@"with artworks > 1", ^{
 });
 
 describe(@"email html", ^{
-    __block Artist *artist;
+    __block Artist *artist, *artist2;
     __block Artwork *artwork;
     __block Image *additionalImage;
-    
+
     beforeEach(^{
         artist = [Artist objectInContext:context];
         artist.displayName = @"Artist Name";
-        
+
+        artist2 = [Artist objectInContext:context];
+        artist2.displayName = @"Other Artist Name";
+
         artwork = [Artwork objectInContext:context];
         artwork.title = @"Artwork Name";
         artwork.artist = artist;
@@ -206,49 +209,55 @@ describe(@"email html", ^{
         Image *mainImage = [ARModelFactory imageWithKnownRemoteResourcesInContext:context];
         mainImage.isMainImage = @(YES);
         mainImage.baseURL = @"http://static0.artsy.net/additional_images/1/";
-        
+
         additionalImage = [ARModelFactory imageWithKnownRemoteResourcesInContext:context];
         additionalImage.isMainImage = @(NO);
         additionalImage.baseURL = @"http://static0.artsy.net/additional_images/2/";
-        
+
         artwork.mainImage = mainImage;
-        artwork.images = [NSSet setWithArray:@[mainImage, additionalImage]];
-        
+        artwork.images = [NSSet setWithArray:@[ mainImage, additionalImage ]];
+
         composer.options = [[AREmailSettings alloc] init];
     });
 
-    
+
     it(@"switches 'artwork' to 'artworks' in greeting when sending multiple artworks", ^{
         defaults[AREmailGreeting] = @"information about the artwork we discussed";
         composer.artworks = @[ artwork, artwork ];
         expect(composer.body).to.contain(@"the artworks we discussed");
     });
-    
+
+    it(@"handles showing multiple artist names for an artwork", ^{
+        artwork.artists = [NSSet setWithObjects:artist, artist2, nil];
+        composer.artworks = @[ artwork ];
+        expect(composer.body).to.contain(artist.displayName);
+    });
+
     it(@"converts newlines in signature to <br/>", ^{
         defaults[AREmailSignature] = @"Hello\nWorld";
         composer.artworks = @[ artwork ];
         expect(composer.body).to.contain(@"Hello<br/>World");
     });
-    
+
     it(@"converts newlines in greetings to <br/>", ^{
         defaults[AREmailGreeting] = @"Hello\nWorld";
         composer.artworks = @[ artwork ];
         expect(composer.body).to.contain(@"Hello<br/>World");
     });
-    
+
     it(@"inlines the images", ^{
         composer.artworks = @[ artwork ];
         expect(composer.body).to.contain([[artwork.mainImage imageURLWithFormatName:ARFeedImageSizeLargeKey] absoluteString]);
     });
-    
+
     it(@"inlines additional images", ^{
         composer.artworks = @[ artwork ];
-        composer.options.additionalImages = @[additionalImage];
+        composer.options.additionalImages = @[ additionalImage ];
         expect(composer.body).to.contain([[additionalImage imageURLWithFormatName:ARFeedImageSizeLargeKey] absoluteString]);
     });
 
     it(@"inlines installation images images", ^{
-        composer.options.installationShots = @[additionalImage];
+        composer.options.installationShots = @[ additionalImage ];
         expect(composer.body).to.contain([[additionalImage imageURLWithFormatName:ARFeedImageSizeLargeKey] absoluteString]);
     });
 
@@ -260,7 +269,7 @@ describe(@"email html", ^{
         expect(composer.body).to.contain(artwork.displayPrice);
     });
 
-    describe(@"with an edition sets" , ^{
+    describe(@"with an edition sets", ^{
 
         it(@"with one edition set", ^{
             composer.artworks = @[ artwork ];
@@ -268,16 +277,16 @@ describe(@"email html", ^{
             EditionSet *set = [EditionSet modelFromJSON:@{
                 ARFeedIDKey : @"123123",
                 ARFeedDimensionsKey : @{
-                    ARFeedDimensionsInchesKey: @"11 inches",
-                    ARFeedDimensionsCMKey: @"23cm"
+                    ARFeedDimensionsInchesKey : @"11 inches",
+                    ARFeedDimensionsCMKey : @"23cm"
                 },
-                ARFeedArtworkEditionsKey: @"Editions Info",
-                ARFeedAvailabilityKey: @"Available Info",
-                ARFeedInternalPriceKey: @"price_internal_123",
-                ARFeedPriceKey: @"price_external_123"
+                ARFeedArtworkEditionsKey : @"Editions Info",
+                ARFeedAvailabilityKey : @"Available Info",
+                ARFeedInternalPriceKey : @"price_internal_123",
+                ARFeedPriceKey : @"price_external_123"
             } inContext:context];
             artwork.editionSets = [NSSet setWithObject:set];
-            
+
             NSString *body = composer.body;
             expect(body).to.contain(set.editions);
             expect(body).to.contain(set.dimensionsCM);
@@ -292,7 +301,7 @@ describe(@"email html", ^{
             composer.options.priceType = AREmailSettingsPriceTypeBackend;
             EditionSet *set = [EditionSet modelFromJSON:@{
                 ARFeedIDKey : @"123123",
-                ARFeedPriceKey: @"price_external_123"
+                ARFeedPriceKey : @"price_external_123"
             } inContext:context];
             artwork.editionSets = [NSSet setWithObject:set];
 
@@ -312,8 +321,8 @@ describe(@"email html", ^{
 
             EditionSet *set = [EditionSet modelFromJSON:@{
                 ARFeedIDKey : @"123123",
-                ARFeedInternalPriceKey: @"price_internal_123",
-                ARFeedPriceKey: @"price_external_123"
+                ARFeedInternalPriceKey : @"price_internal_123",
+                ARFeedPriceKey : @"price_external_123"
             } inContext:context];
             artwork.editionSets = [NSSet setWithObject:set];
 
@@ -327,11 +336,11 @@ describe(@"email html", ^{
 
             EditionSet *set = [EditionSet modelFromJSON:@{
                 ARFeedIDKey : @"123123",
-                ARFeedInternalPriceKey: @"price_internal_123",
-                ARFeedPriceKey: @"price_external_123"
+                ARFeedInternalPriceKey : @"price_internal_123",
+                ARFeedPriceKey : @"price_external_123"
             } inContext:context];
             artwork.editionSets = [NSSet setWithObject:set];
-            
+
             expect(composer.body).to.contain(set.backendPrice);
             expect(composer.body).toNot.contain(set.displayPrice);
         });

--- a/ArtsyFolio Tests/Util/ARSelectionHandlerTests.m
+++ b/ArtsyFolio Tests/Util/ARSelectionHandlerTests.m
@@ -50,7 +50,7 @@ describe(@"when selecting", ^{
 
         Artwork *artwork = [Artwork objectInContext:context];
         Artist *artist = [Artist objectInContext:context];
-        artwork.artist = artist;
+        artwork.artists = [NSSet setWithObject:artist];
 
         [handler selectObject:artwork];
         [handler commitSelection];

--- a/ArtsyFolio Tests/View Controllers/AREditAlbumViewControllerTests.m
+++ b/ArtsyFolio Tests/View Controllers/AREditAlbumViewControllerTests.m
@@ -47,37 +47,37 @@ describe(@"on init", ^{
 describe(@"visuals", ^{
     __block Artwork *artwork;
     __block Album *album;
-    
+
     dispatch_block_t before = ^{
-        context  = [CoreDataManager stubbedManagedObjectContext];
+        context = [CoreDataManager stubbedManagedObjectContext];
         artwork = [ARModelFactory partiallyFilledArtworkInContext:context];
         Image *image = [Image objectInContext:context];
         [[NSUserDefaults standardUserDefaults] setBool:NO forKey:AROptionsUseWhiteFolio];
 
         album = [Album objectInContext:context];
         album.name = @"Test";
-        
+
         Artist *artist = [ARModelFactory filledArtistInContext:context];
-        artist.artworks = [NSSet setWithObject:artwork];
+        artwork.artists = [NSSet setWithObject:artist];
         artwork.mainImage = image;
-        
+
         ARAlbumEditNavigationController *navController = [[ARAlbumEditNavigationController alloc] initWithAlbum:album];
         editVC = [[AREditAlbumViewController alloc] initWithAlbum:album];
-        [navController setViewControllers:@[editVC] animated:NO];
+        [navController setViewControllers:@[ editVC ] animated:NO];
     };
-    
+
     itHasSnapshotsForDevices(@"default", ^{
         before();
         return editVC.navigationController;
     });
-    
-    
+
+
     itHasSnapshotsForDevices(@"with existing album", ^{
         before();
         album.artworks = [NSSet setWithObject:artwork];
         return editVC.navigationController;
     });
-    
+
     itHasSnapshotsForDevices(@"with existing items selected", ^{
         before();
 
@@ -89,7 +89,7 @@ describe(@"visuals", ^{
         [editVC endAppearanceTransition];
 
         [handler selectObject:artwork];
-        
+
         return editVC.navigationController;
     });
 
@@ -149,39 +149,39 @@ pending(@"subtitle", ^{
         [editVC beginAppearanceTransition:YES animated:NO];
         [editVC endAppearanceTransition];
     });
-    
+
     it(@"says item when only one item is selected", ^{
-        [[[editVC.selectionHandler stub] andReturn:@[@1]] selectedObjects];
+        [[[editVC.selectionHandler stub] andReturn:@[ @1 ]] selectedObjects];
         [editVC updateSubtitleAnimated:NO];
-        
+
         NSString *subtitle = editVC.phoneTitleLabel.label.text;
         expect(subtitle).toNot.contain(@"ITEMS");
         expect(subtitle).to.contain(@"ITEM");
     });
-    
+
     it(@"says items when more than one item is selected", ^{
-        [[[editVC.selectionHandler stub] andReturn:@[@1, @2]] selectedObjects];
+        [[[editVC.selectionHandler stub] andReturn:@[ @1, @2 ]] selectedObjects];
         [editVC updateTitle];
-        
+
         NSString *subtitle = editVC.phoneTitleLabel.label.text;
         expect(subtitle).to.contain(@"ITEMS");
     });
-    
+
     it(@"says remove when there are items being removed", ^{
-        [[[editVC.selectionHandler stub] andReturn:@[@1, @2]] selectedObjects];
+        [[[editVC.selectionHandler stub] andReturn:@[ @1, @2 ]] selectedObjects];
         editVC.initialArtworksCount = 3;
-        
+
         [editVC updateSubtitleAnimated:NO];
-        
+
         NSString *subtitle = editVC.phoneTitleLabel.label.text;
         expect(subtitle).to.contain(@"REMOVE");
     });
-    
+
     it(@"says add when there are items being added", ^{
-        [[[editVC.selectionHandler stub] andReturn:@[@1, @2]] selectedObjects];
-        
+        [[[editVC.selectionHandler stub] andReturn:@[ @1, @2 ]] selectedObjects];
+
         [editVC updateSubtitleAnimated:NO];
-        
+
         NSString *subtitle = editVC.phoneTitleLabel.label.text;
         expect(subtitle).to.contain(@"ADD");
     });

--- a/ArtsyFolio Tests/View Controllers/ARModernEmailArtworksViewControllerTests.m
+++ b/ArtsyFolio Tests/View Controllers/ARModernEmailArtworksViewControllerTests.m
@@ -36,7 +36,7 @@ it(@"email popovers", ^{
     artist.documents = [NSSet setWithObject:document];
 
     Artwork *artwork = [Artwork objectInContext:context];
-    artwork.artist = artist;
+    artwork.artists = [NSSet setWithObject:artist];
 
     // A show
     Show *show = [Show objectInContext:context];
@@ -44,9 +44,9 @@ it(@"email popovers", ^{
     Artwork *artwork2 = [Artwork objectInContext:context];
     show.artworks = [NSSet setWithObject:artwork2];
 
-    artworks = @[artwork, artwork2];
+    artworks = @[ artwork, artwork2 ];
 
-    [ARTestContext useContext:ARTestContextDeviceTypePhone5 :^{
+    [ARTestContext useContext:ARTestContextDeviceTypePhone5:^{
 
         subject = [[ARModernEmailArtworksViewController alloc] initWithArtworks:artworks documents:documents installShots:@[] context:artist];
         expect(subject).to.haveValidSnapshotNamed(@"with artworks + show");
@@ -58,7 +58,7 @@ it(@"email popovers", ^{
         expect(subject).to.haveValidSnapshotNamed(@"show context with install shots");
 
         show.documents = [NSSet setWithObject:document];
-        documents = @[document];
+        documents = @[ document ];
 
         subject = [[ARModernEmailArtworksViewController alloc] initWithArtworks:artworks documents:documents installShots:@[] context:artist];
         expect(subject).to.haveValidSnapshotNamed(@"with documents");
@@ -71,23 +71,23 @@ it(@"email popovers", ^{
         subject = [[ARModernEmailArtworksViewController alloc] initWithArtworks:artworks documents:documents installShots:@[] context:artist];
         expect(subject).to.haveValidSnapshotNamed(@"with artwork metadata");
 
-        NSArray *images = @[[LocalImage objectInContext:context], [LocalImage objectInContext:context]];
+        NSArray *images = @[ [LocalImage objectInContext:context], [LocalImage objectInContext:context] ];
         artwork.images = [NSSet setWithArray:images];
         subject = [[ARModernEmailArtworksViewController alloc] initWithArtworks:artworks documents:documents installShots:@[] context:artist];
         expect(subject).to.haveValidSnapshotNamed(@"additional images");
 
         Artwork *artwork2 = [Artwork objectInContext:context];
-        images = @[[LocalImage objectInContext:context], [LocalImage objectInContext:context]];
+        images = @[ [LocalImage objectInContext:context], [LocalImage objectInContext:context] ];
         artwork2.images = [NSSet setWithArray:images];
-        subject = [[ARModernEmailArtworksViewController alloc] initWithArtworks:@[artwork2] documents:nil installShots:@[] context: artist];
+        subject = [[ARModernEmailArtworksViewController alloc] initWithArtworks:@[ artwork2 ] documents:nil installShots:@[] context:artist];
         expect(subject).to.haveValidSnapshotNamed(@"additional images with no artwork metadata");
 
         Artwork *artwork3 = [Artwork objectInContext:context];
         artwork3.displayPrice = @"price";
         artwork3.backendPrice = @"backend price";
-        images = @[[LocalImage objectInContext:context], [LocalImage objectInContext:context]];
+        images = @[ [LocalImage objectInContext:context], [LocalImage objectInContext:context] ];
         artwork2.images = [NSSet setWithArray:images];
-        subject = [[ARModernEmailArtworksViewController alloc] initWithArtworks:@[artwork3] documents:nil installShots:@[] context:artist];
+        subject = [[ARModernEmailArtworksViewController alloc] initWithArtworks:@[ artwork3 ] documents:nil installShots:@[] context:artist];
         expect(subject).to.haveValidSnapshotNamed(@"shows exact prices when available");
 
     }];
@@ -139,7 +139,7 @@ describe(@"email settings object", ^{
             Artwork *artwork = [Artwork objectInContext:context];
             artwork.displayPrice = @"111";
 
-            subject = [[ARModernEmailArtworksViewController alloc] initWithArtworks:@[artwork] documents:nil installShots:@[] context:nil];
+            subject = [[ARModernEmailArtworksViewController alloc] initWithArtworks:@[ artwork ] documents:nil installShots:@[] context:nil];
             subject.userDefaults = (id)[[ForgeriesUserDefaults alloc] init];
             defaults = (id)subject.userDefaults;
         });
@@ -188,8 +188,8 @@ describe(@"passing objects", ^{
         image = [InstallShotImage objectInContext:context];
         show.installationImages = [NSSet setWithObject:image];
 
-        artworks = @[artwork, artwork2];
-        documents = @[document];
+        artworks = @[ artwork, artwork2 ];
+        documents = @[ document ];
 
         subject = [[ARModernEmailArtworksViewController alloc] initWithArtworks:artworks documents:documents installShots:@[] context:nil];
         subject.userDefaults = (id)[[ForgeriesUserDefaults alloc] init];
@@ -216,7 +216,7 @@ describe(@"passing objects", ^{
             image.imageFilePath = localImagePath;
 
             selection = [[ARThumbnailImageSelectionView alloc] initWithFrame:CGRectMake(0, 0, 1, 1)];
-            [selection setImages:@[image]];
+            [selection setImages:@[ image ]];
             [selection selectAll];
         });
 
@@ -226,7 +226,7 @@ describe(@"passing objects", ^{
         });
 
         it(@"selected additional images", ^{
-            subject = [[ARModernEmailArtworksViewController alloc] initWithArtworks:@[artwork2] documents:nil installShots:@[] context:nil];
+            subject = [[ARModernEmailArtworksViewController alloc] initWithArtworks:@[ artwork2 ] documents:nil installShots:@[] context:nil];
             subject.additionalImagesSelectionView = selection;
 
             expect(subject.emailSettings.additionalImages).to.contain(additionalImage);
@@ -245,7 +245,7 @@ describe(@"incoming selection state", ^{
         document.slug = @"ExampleDocument";
         document.hasFile = @YES;
 
-        subject = [[ARModernEmailArtworksViewController alloc] initWithArtworks:@[] documents:@[document] installShots:@[] context:nil];
+        subject = [[ARModernEmailArtworksViewController alloc] initWithArtworks:@[] documents:@[ document ] installShots:@[] context:nil];
         subject.userDefaults = (id)[[ForgeriesUserDefaults alloc] init];
         defaults = (id)subject.userDefaults;
 
@@ -260,7 +260,7 @@ describe(@"incoming selection state", ^{
 
         InstallShotImage *image = [InstallShotImage objectInContext:context];
         image.slug = @"InstallImageSlug";
-        subject = [[ARModernEmailArtworksViewController alloc] initWithArtworks:@[] documents:@[] installShots:@[image] context:nil];
+        subject = [[ARModernEmailArtworksViewController alloc] initWithArtworks:@[] documents:@[] installShots:@[ image ] context:nil];
         subject.userDefaults = (id)[[ForgeriesUserDefaults alloc] init];
         defaults = (id)subject.userDefaults;
 

--- a/ArtsyFolio Tests/View Controllers/ARPresentationModeSettingsViewControllerTests.m
+++ b/ArtsyFolio Tests/View Controllers/ARPresentationModeSettingsViewControllerTests.m
@@ -23,18 +23,18 @@ beforeAll(^{
 beforeEach(^{
     context = [CoreDataManager stubbedManagedObjectContext];
     [Partner objectInContext:context];
-    
+
     subject = [storyboard instantiateViewControllerWithIdentifier:PresentationModeViewController];
     subject.context = context;
 });
 
 describe(@"when showing and hiding toggles", ^{
-    
+
     /// The 'Hide Confidential Notes' & 'Hide Artwork Edit Button' are always visible
     it(@"shows all prices toggle when artworks exist with prices", ^{
         Artwork *priceArtwork = genericArtworkInContext(context);
         priceArtwork.displayPrice = @"200";
-        
+
         expect(numberOfRowsIn(subject)).to.equal(3);
     });
 
@@ -45,35 +45,34 @@ describe(@"when showing and hiding toggles", ^{
 
         expect(numberOfRowsIn(subject)).to.equal(2);
     });
-    
+
     it(@"shows Hide Prices For Sold Works and Hide Not For Sale Works toggles when there are sold works with prices", ^{
         Artwork *soldArtwork = genericArtworkInContext(context);
         soldArtwork.availability = @"sold";
         soldArtwork.backendPrice = @"10";
         soldArtwork.isAvailableForSale = @(NO);
-        
+
         expect(numberOfRowsIn(subject)).to.equal(4);
     });
-    
+
     it(@"shows Hide Unpublished Works when there are both published and unpublished works", ^{
-        Artwork *publishedArtwork = genericArtworkInContext(context);
-        
+        genericArtworkInContext(context);
+
         Artwork *unpublishedArtwork = genericArtworkInContext(context);
         unpublishedArtwork.isPublished = @(NO);
-        
+
         expect(numberOfRowsIn(subject)).to.equal(3);
     });
-    
+
     it(@"doesn't show Hide Unpublished Works when there are only unpublished works", ^{
         Artwork *unpublishedArtwork = genericArtworkInContext(context);
         unpublishedArtwork.isPublished = @(NO);
-        
+
         expect(numberOfRowsIn(subject)).to.equal(2);
     });
-    
+
     it(@"doesn't show Hide Unpublished Works when there are only published works", ^{
-        Artwork *publishedArtwork = genericArtworkInContext(context);
-        
+        genericArtworkInContext(context);
         expect(numberOfRowsIn(subject)).to.equal(2);
     });
 
@@ -88,7 +87,7 @@ describe(@"setting defaults", ^{
         Artwork *publishedArtwork = genericArtworkInContext(context);
         publishedArtwork.backendPrice = @"32";
         publishedArtwork.availability = @"sold";
-        
+
         Artwork *unpublishedArtwork = genericArtworkInContext(context);
         unpublishedArtwork.isPublished = @(NO);
         unpublishedArtwork.isAvailableForSale = @(NO);
@@ -96,9 +95,9 @@ describe(@"setting defaults", ^{
 
         subject.defaults = (id)offDefaults();
         [subject.defaults setBool:YES forKey:ARHasInitializedPresentationMode];
-        
+
         [navController pushViewController:subject animated:NO];
-        
+
         expect(navController).to.haveValidSnapshot();
     });
 
@@ -106,16 +105,16 @@ describe(@"setting defaults", ^{
         Artwork *publishedArtwork = genericArtworkInContext(context);
         publishedArtwork.backendPrice = @"32";
         publishedArtwork.availability = @"sold";
-        
+
         Artwork *unpublishedArtwork = genericArtworkInContext(context);
         unpublishedArtwork.isPublished = @(NO);
         unpublishedArtwork.isAvailableForSale = @(NO);
         unpublishedArtwork.confidentialNotes = @"fjdkalfjdks";
-        
+
         subject.defaults = (id)onDefaults();
-        
+
         [navController pushViewController:subject animated:NO];
-        
+
         expect(navController).to.haveValidSnapshot();
     });
 
@@ -125,12 +124,12 @@ describe(@"setting defaults", ^{
     it(@"sets the right default when tapped", ^{
         Artwork *artwork = genericArtworkInContext(context);
         artwork.displayPrice = @"2";
-        
+
         subject.defaults = (id)offDefaults();
-        
+
         NSIndexPath *path = [NSIndexPath indexPathForRow:0 inSection:0];
         [subject tableView:subject.tableView didSelectRowAtIndexPath:path];
-        
+
         ForgeriesUserDefaults *defaults = (id)subject.defaults;
         expect(defaults.hasSyncronised).to.beTruthy();
         expect(defaults.lastRequestedKey).to.equal(ARHideAllPrices);
@@ -139,32 +138,32 @@ describe(@"setting defaults", ^{
 });
 
 describe(@"selecting an artwork filtering cell", ^{
-    
+
     it(@"posts a notification if presentation mode is on", ^{
-        Artwork *artwork1 = genericArtworkInContext(context);
+        genericArtworkInContext(context);
         Artwork *artwork2 = genericArtworkInContext(context);
         artwork2.isAvailableForSale = @(NO);
-        
+
         NSIndexPath *hideNotForSaleWorksIndexPath = [NSIndexPath indexPathForRow:0 inSection:0];
 
         subject.defaults = (id)onDefaults();
         [subject.defaults setBool:YES forKey:ARPresentationModeOn];
-        
+
         expect(^{
             [subject tableView:subject.tableView didSelectRowAtIndexPath:hideNotForSaleWorksIndexPath];
         }).to.notify(ARUserDidChangeGridFilteringSettingsNotification);
     });
-    
+
     it(@"does not post a notification if presentation mode is off", ^{
-        Artwork *artwork1 = genericArtworkInContext(context);
+        genericArtworkInContext(context);
         Artwork *artwork2 = genericArtworkInContext(context);
         artwork2.isPublished = @(NO);
-        
+
         NSIndexPath *hideUnpublishedWorksIndexPath = [NSIndexPath indexPathForRow:0 inSection:0];
-        
+
         subject.defaults = (id)onDefaults();
         [subject.defaults setBool:NO forKey:ARPresentationModeOn];
-        
+
         expect(^{
             [subject tableView:subject.tableView didSelectRowAtIndexPath:hideUnpublishedWorksIndexPath];
         }).toNot.notify(ARUserDidChangeGridFilteringSettingsNotification);

--- a/ArtsyFolio Tests/View Controllers/ARSearchViewControllerTests.m
+++ b/ArtsyFolio Tests/View Controllers/ARSearchViewControllerTests.m
@@ -147,11 +147,14 @@ describe(@"tapping a results sends the right message to the delegate", ^{
 
     __block NSIndexPath *zeroPath;
     __block OCMockObject *delegateMock;
+    __block UITableView *tableView;
+
 
     before(^{
+        tableView = [[UITableView alloc] init];
         delegateMock = [OCMockObject mockForProtocol:@protocol(ARSearchViewControllerDelegate)];
         sut.delegate = (id)delegateMock;
-        zeroPath= [NSIndexPath indexPathForRow:0 inSection:0];
+        zeroPath = [NSIndexPath indexPathForRow:0 inSection:0];
     });
 
     it(@"artworks", ^{
@@ -163,9 +166,11 @@ describe(@"tapping a results sends the right message to the delegate", ^{
         [[delegateMock expect] searchViewController:sut didSelectArtwork:artwork];
 
         [sut performSearchForText:@"hi"];
-        [sut tableView:nil didSelectRowAtIndexPath:zeroPath];
+        [sut tableView:tableView didSelectRowAtIndexPath:zeroPath];
 
-        expect(^{ [delegateMock verify]; }).toNot.raiseAny();
+        expect(^{
+            [delegateMock verify];
+        }).toNot.raiseAny();
     });
 
     it(@"Artists", ^{
@@ -175,9 +180,11 @@ describe(@"tapping a results sends the right message to the delegate", ^{
         [[delegateMock expect] searchViewController:sut didSelectArtist:artist];
 
         [sut performSearchForText:@"he"];
-        [sut tableView:nil didSelectRowAtIndexPath:zeroPath];
+        [sut tableView:tableView didSelectRowAtIndexPath:zeroPath];
 
-        expect(^{ [delegateMock verify]; }).toNot.raiseAny();
+        expect(^{
+            [delegateMock verify];
+        }).toNot.raiseAny();
     });
 
     it(@"Shows", ^{
@@ -187,9 +194,11 @@ describe(@"tapping a results sends the right message to the delegate", ^{
         [[delegateMock expect] searchViewController:sut didSelectShow:show];
 
         [sut performSearchForText:@"its"];
-        [sut tableView:nil didSelectRowAtIndexPath:zeroPath];
+        [sut tableView:tableView didSelectRowAtIndexPath:zeroPath];
 
-        expect(^{ [delegateMock verify]; }).toNot.raiseAny();
+        expect(^{
+            [delegateMock verify];
+        }).toNot.raiseAny();
     });
 
     it(@"Locations", ^{
@@ -199,9 +208,11 @@ describe(@"tapping a results sends the right message to the delegate", ^{
         [[delegateMock expect] searchViewController:sut didSelectLocation:location];
 
         [sut performSearchForText:@"its"];
-        [sut tableView:nil didSelectRowAtIndexPath:zeroPath];
+        [sut tableView:tableView didSelectRowAtIndexPath:zeroPath];
 
-        expect(^{ [delegateMock verify]; }).toNot.raiseAny();
+        expect(^{
+            [delegateMock verify];
+        }).toNot.raiseAny();
     });
 
     it(@"Albums", ^{
@@ -211,9 +222,11 @@ describe(@"tapping a results sends the right message to the delegate", ^{
         [[delegateMock expect] searchViewController:sut didSelectAlbum:album];
 
         [sut performSearchForText:@"its"];
-        [sut tableView:nil didSelectRowAtIndexPath:zeroPath];
+        [sut tableView:tableView didSelectRowAtIndexPath:zeroPath];
 
-        expect(^{ [delegateMock verify]; }).toNot.raiseAny();
+        expect(^{
+            [delegateMock verify];
+        }).toNot.raiseAny();
     });
 
 });

--- a/ArtsyFolio Tests/View Controllers/ARSettingsMenuViewControllerTests.m
+++ b/ArtsyFolio Tests/View Controllers/ARSettingsMenuViewControllerTests.m
@@ -15,9 +15,7 @@ ARSettingsMenuViewModel *viewModelWithDefaultsAndContext(NSDictionary *defaults,
 SpecBegin(ARSettingsMenuViewController);
 
 __block ARSettingsMenuViewController *subject;
-__block ARSettingsMenuViewModel *viewModel;
 __block UIStoryboard *storyboard;
-__block ForgeriesUserDefaults *defaults;
 __block NSManagedObjectContext *context;
 
 beforeAll(^{
@@ -27,67 +25,85 @@ beforeAll(^{
 beforeEach(^{
     subject = [storyboard instantiateViewControllerWithIdentifier:SettingsMasterViewController];
     context = [CoreDataManager stubbedManagedObjectContext];
-    Partner *partner = [Partner createInContext:context];
+    [Partner createInContext:context];
 });
 
 describe(@"visuals", ^{
     itHasSnapshotsForDevices(@"looks right by default", ^{
-        
+
         /// This should show an enabled presentation mode toggle
-        subject.viewModel = viewModelWithDefaultsAndContext(@{ ARPresentationModeOn: @NO}, context);
-        
+        subject.viewModel = viewModelWithDefaultsAndContext(@{ ARPresentationModeOn : @NO }, context);
+
         UINavigationController *nav = [storyboard instantiateViewControllerWithIdentifier:SettingsPrimaryNavigationController];
         [nav pushViewController:subject animated:NO];
 
         return nav;
     });
-    
+
     it(@"looks right after presentation mode is initialized and on", ^{
-        subject.viewModel = viewModelWithDefaultsAndContext(@{ ARHasInitializedPresentationMode: @YES, ARPresentationModeOn: @YES, ARHideWorksNotForSale: @YES }, context);
+        subject.viewModel = viewModelWithDefaultsAndContext(@{ ARHasInitializedPresentationMode : @YES,
+                                                               ARPresentationModeOn : @YES,
+                                                               ARHideWorksNotForSale : @YES },
+                                                            context);
         expect(subject).to.haveValidSnapshot();
     });
 });
 
 describe(@"toggling presentation mode", ^{
-    
+
     it(@"posts a grid view filtering notification when turning pres mode on", ^{
-        subject.viewModel = viewModelWithDefaultsAndContext(@{ ARHasInitializedPresentationMode: @YES, ARPresentationModeOn: @NO, ARHideConfidentialNotes: @YES }, context);
+        subject.viewModel = viewModelWithDefaultsAndContext(@{ ARHasInitializedPresentationMode : @YES,
+                                                               ARPresentationModeOn : @NO,
+                                                               ARHideConfidentialNotes : @YES },
+                                                            context);
 
         [subject beginAppearanceTransition:YES animated:NO];
-        expect(^{[subject presentationModeButtonPressed:nil];}).to.notify(ARUserDidChangeGridFilteringSettingsNotification);
+        expect(^{
+            [subject presentationModeButtonPressed:nil];
+        }).to.notify(ARUserDidChangeGridFilteringSettingsNotification);
     });
 
     it(@"posts a grid view filtering notification when turning pres mode off", ^{
-        subject.viewModel = viewModelWithDefaultsAndContext(@{ ARHasInitializedPresentationMode: @YES, ARPresentationModeOn: @YES, ARHideWorksNotForSale:@YES }, context);
-        
-        [subject beginAppearanceTransition:YES animated:NO];         
-        expect(^{[subject presentationModeButtonPressed:nil];}).to.notify(ARUserDidChangeGridFilteringSettingsNotification);
+        subject.viewModel = viewModelWithDefaultsAndContext(@{ ARHasInitializedPresentationMode : @YES,
+                                                               ARPresentationModeOn : @YES,
+                                                               ARHideWorksNotForSale : @YES },
+                                                            context);
+
+        [subject beginAppearanceTransition:YES animated:NO];
+        expect(^{
+            [subject presentationModeButtonPressed:nil];
+        }).to.notify(ARUserDidChangeGridFilteringSettingsNotification);
     });
-    
+
     it(@"disables toggle when all pres mode settings are off", ^{
-        subject.viewModel = viewModelWithDefaultsAndContext(@{ ARHasInitializedPresentationMode: @YES, ARPresentationModeOn: @YES }, context);
+        subject.viewModel = viewModelWithDefaultsAndContext(@{ ARHasInitializedPresentationMode : @YES,
+                                                               ARPresentationModeOn : @YES },
+                                                            context);
 
         /// Should disable toggle because no presentation mode settings are on
         expect(subject).to.haveValidSnapshot();
     });
-    
+
     it(@"enables the toggle when any pres mode settings are on", ^{
-        subject.viewModel = viewModelWithDefaultsAndContext(@{ ARHasInitializedPresentationMode: @YES, ARPresentationModeOn: @NO, ARHideArtworkEditButton: @YES }, context);
-        
+        subject.viewModel = viewModelWithDefaultsAndContext(@{ ARHasInitializedPresentationMode : @YES,
+                                                               ARPresentationModeOn : @NO,
+                                                               ARHideArtworkEditButton : @YES },
+                                                            context);
+
         expect(subject).to.haveValidSnapshot();
     });
 });
 
 describe(@"showing and hiding the sync recommendation badge", ^{
     it(@"shows the badge when it should recommend a sync", ^{
-        subject.viewModel = viewModelWithDefaultsAndContext(@{ ARRecommendSync: @YES }, context);
-        
+        subject.viewModel = viewModelWithDefaultsAndContext(@{ ARRecommendSync : @YES }, context);
+
         expect(subject).to.haveValidSnapshot();
     });
-    
+
     it(@"hides the badge when sync is up to date", ^{
-        subject.viewModel = viewModelWithDefaultsAndContext(@{ ARRecommendSync: @NO }, context);
-        
+        subject.viewModel = viewModelWithDefaultsAndContext(@{ ARRecommendSync : @NO }, context);
+
         expect(subject).to.haveValidSnapshot();
     });
 });

--- a/ArtsyFolio Tests/View Controllers/Email Artworks/ARModernEmailArtworksViewControllerDataSourceTests.m
+++ b/ArtsyFolio Tests/View Controllers/Email Artworks/ARModernEmailArtworksViewControllerDataSourceTests.m
@@ -16,106 +16,110 @@ describe(@"showing additional images", ^{
     it(@"returns true only when there's one artwork with additional images", ^{
         Artwork *artwork = [Artwork objectInContext:context];
         artwork.images = [NSSet setWithObjects:[Image objectInContext:context], [Image objectInContext:context], nil];
-        expect([subject artworksShouldShowAdditionalImages:@[artwork]]).to.beTruthy();
+        expect([subject artworksShouldShowAdditionalImages:@[ artwork ]]).to.beTruthy();
     });
 
     it(@"returns false when there's two artworks, even if one has additional images", ^{
         Artwork *artwork = [Artwork objectInContext:context];
         artwork.images = [NSSet setWithObjects:[Image objectInContext:context], [Image objectInContext:context], nil];
         Artwork *artwork2 = [Artwork objectInContext:context];
-        expect([subject artworksShouldShowAdditionalImages:@[artwork, artwork2]]).to.beFalsy();
+        expect([subject artworksShouldShowAdditionalImages:@[ artwork, artwork2 ]]).to.beFalsy();
     });
 
     it(@"returns false the artwork has no additional images", ^{
         Artwork *artwork = [Artwork objectInContext:context];
-        expect([subject artworksShouldShowAdditionalImages:@[artwork]]).to.beFalsy();
+        expect([subject artworksShouldShowAdditionalImages:@[ artwork ]]).to.beFalsy();
     });
 });
 
 describe(@"showing prices", ^{
     it(@"returns true when there's one artwork with pricing", ^{
-        Artwork *artwork = [Artwork modelFromJSON:@{ ARFeedPriceKey : @"23"} inContext:context];
+        Artwork *artwork = [Artwork modelFromJSON:@{ ARFeedPriceKey : @"23" } inContext:context];
         Artwork *artwork2 = [Artwork objectInContext:context];
 
-        expect([subject artworksShouldShowPrice:@[artwork, artwork2]]).to.beTruthy();
+        expect([subject artworksShouldShowPrice:@[ artwork, artwork2 ]]).to.beTruthy();
     });
 
     it(@"returns false when there's one artwork with pricing but it is 0 length", ^{
-        Artwork *artwork = [Artwork modelFromJSON:@{ ARFeedPriceKey : @""} inContext:context];
+        Artwork *artwork = [Artwork modelFromJSON:@{ ARFeedPriceKey : @"" } inContext:context];
         Artwork *artwork2 = [Artwork objectInContext:context];
 
-        expect([subject artworksShouldShowPrice:@[artwork, artwork2]]).to.beFalsy();
+        expect([subject artworksShouldShowPrice:@[ artwork, artwork2 ]]).to.beFalsy();
     });
 
     it(@"returns false if no artworks have a price", ^{
         Artwork *artwork = [Artwork objectInContext:context];
         Artwork *artwork2 = [Artwork objectInContext:context];
 
-        expect([subject artworksShouldShowPrice:@[artwork, artwork2]]).to.beFalsy();
+        expect([subject artworksShouldShowPrice:@[ artwork, artwork2 ]]).to.beFalsy();
     });
 });
 
 describe(@"showing backend prices", ^{
     it(@"returns true when there's one artwork with pricing", ^{
-        Artwork *artwork = [Artwork modelFromJSON:@{ ARFeedPriceKey : @"23", ARFeedInternalPriceKey: @"24" } inContext:context];
+        Artwork *artwork = [Artwork modelFromJSON:@{ ARFeedPriceKey : @"23",
+                                                     ARFeedInternalPriceKey : @"24" }
+                                        inContext:context];
         Artwork *artwork2 = [Artwork objectInContext:context];
 
-        expect([subject artworksShouldShowPrice:@[artwork, artwork2]]).to.beTruthy();
+        expect([subject artworksShouldShowPrice:@[ artwork, artwork2 ]]).to.beTruthy();
     });
 
 
     it(@"returns false when there's one artwork with the same display price as internal price", ^{
-        Artwork *artwork = [Artwork modelFromJSON:@{ ARFeedPriceKey : @"23", ARFeedInternalPriceKey : @"23" } inContext:context];
+        Artwork *artwork = [Artwork modelFromJSON:@{ ARFeedPriceKey : @"23",
+                                                     ARFeedInternalPriceKey : @"23" }
+                                        inContext:context];
         Artwork *artwork2 = [Artwork objectInContext:context];
 
-        expect([subject artworksShouldShowBackendPrice:@[artwork, artwork2]]).to.beFalsy();
+        expect([subject artworksShouldShowBackendPrice:@[ artwork, artwork2 ]]).to.beFalsy();
     });
 
     it(@"returns false when there's one artwork with pricing but it is 0 length", ^{
-        Artwork *artwork = [Artwork modelFromJSON:@{ ARFeedPriceKey : @""} inContext:context];
+        Artwork *artwork = [Artwork modelFromJSON:@{ ARFeedPriceKey : @"" } inContext:context];
         Artwork *artwork2 = [Artwork objectInContext:context];
 
-        expect([subject artworksShouldShowBackendPrice:@[artwork, artwork2]]).to.beFalsy();
+        expect([subject artworksShouldShowBackendPrice:@[ artwork, artwork2 ]]).to.beFalsy();
     });
 
     it(@"returns false if no artworks have a price", ^{
         Artwork *artwork = [Artwork objectInContext:context];
         Artwork *artwork2 = [Artwork objectInContext:context];
 
-        expect([subject artworksShouldShowBackendPrice:@[artwork, artwork2]]).to.beFalsy();
+        expect([subject artworksShouldShowBackendPrice:@[ artwork, artwork2 ]]).to.beFalsy();
     });
 });
 
 
 describe(@"showing supplementary info", ^{
     it(@"returns true when there's one artwork has Supplementary info", ^{
-        Artwork *artwork = [Artwork modelFromJSON:@{ ARFeedSeriesKey : @"23"} inContext:context];
+        Artwork *artwork = [Artwork modelFromJSON:@{ ARFeedSeriesKey : @"23" } inContext:context];
         Artwork *artwork2 = [Artwork objectInContext:context];
 
-        expect([subject artworksShouldShowSupplementaryInfo:@[artwork, artwork2]]).to.beTruthy();
+        expect([subject artworksShouldShowSupplementaryInfo:@[ artwork, artwork2 ]]).to.beTruthy();
     });
 
     it(@"returns false if no artworks have Supplementary info", ^{
         Artwork *artwork = [Artwork objectInContext:context];
         Artwork *artwork2 = [Artwork objectInContext:context];
 
-        expect([subject artworksShouldShowSupplementaryInfo:@[artwork, artwork2]]).to.beFalsy();
+        expect([subject artworksShouldShowSupplementaryInfo:@[ artwork, artwork2 ]]).to.beFalsy();
     });
 });
 
 describe(@"showing inventory ID", ^{
     it(@"returns true when there's one artwork with an inventory ID", ^{
-        Artwork *artwork = [Artwork modelFromJSON:@{ ARFeedInventoryIDKey : @"23"} inContext:context];
+        Artwork *artwork = [Artwork modelFromJSON:@{ ARFeedInventoryIDKey : @"23" } inContext:context];
         Artwork *artwork2 = [Artwork objectInContext:context];
 
-        expect([subject artworksShouldShowInventoryID:@[artwork, artwork2]]).to.beTruthy();
+        expect([subject artworksShouldShowInventoryID:@[ artwork, artwork2 ]]).to.beTruthy();
     });
 
     it(@"returns false if no artworks have an inventory ID", ^{
         Artwork *artwork = [Artwork objectInContext:context];
         Artwork *artwork2 = [Artwork objectInContext:context];
 
-        expect([subject artworksShouldShowInventoryID:@[artwork, artwork2]]).to.beFalsy();
+        expect([subject artworksShouldShowInventoryID:@[ artwork, artwork2 ]]).to.beFalsy();
     });
 });
 
@@ -134,9 +138,9 @@ describe(@"installation shots", ^{
         show.installationImages = [NSSet setWithObject:image];
         show.artworks = [NSSet setWithObject:artwork];
 
-        NSArray *installationShots = [subject installationShotsForArtworks:@[artwork] context:nil];
+        NSArray *installationShots = [subject installationShotsForArtworks:@[ artwork ] context:nil];
         expect(installationShots.count).to.beGreaterThan(0);
-        expect([subject artworksShouldShowInstallShots:@[artwork] context:nil]).to.beTruthy();
+        expect([subject artworksShouldShowInstallShots:@[ artwork ] context:nil]).to.beTruthy();
     });
 
     it(@"returns true when there is a context as a show with installation shots", ^{
@@ -146,17 +150,17 @@ describe(@"installation shots", ^{
         show.artworks = [NSSet setWithObject:artwork];
         show2.artworks = [NSSet setWithObject:artwork];
 
-        NSArray *installationShots = [subject installationShotsForArtworks:@[show] context:show];
+        NSArray *installationShots = [subject installationShotsForArtworks:@[ show ] context:show];
         expect(installationShots.count).to.beGreaterThan(0);
-        expect([subject artworksShouldShowInstallShots:@[artwork] context:nil]).to.beTruthy();
+        expect([subject artworksShouldShowInstallShots:@[ artwork ] context:nil]).to.beTruthy();
     });
 
     it(@"returns false if no artworks with shows have installation shots", ^{
         show.artworks = [NSSet setWithObject:artwork];
 
-        NSArray *installationShots = [subject installationShotsForArtworks:@[show] context:show];
+        NSArray *installationShots = [subject installationShotsForArtworks:@[ show ] context:show];
         expect(installationShots.count).to.equal(0);
-        expect([subject artworksShouldShowInstallShots:@[artwork] context:nil]).to.beFalsy();
+        expect([subject artworksShouldShowInstallShots:@[ artwork ] context:nil]).to.beFalsy();
     });
 
 
@@ -173,9 +177,9 @@ describe(@"installation shots", ^{
         show2.artworks = [NSSet setWithObject:artwork];
         artwork.shows = [NSSet setWithObjects:show, show2, nil];
 
-        NSArray *installationShots = [subject installationShotsForArtworks:@[artwork] context:nil];
+        NSArray *installationShots = [subject installationShotsForArtworks:@[ artwork ] context:nil];
         expect(installationShots.count).to.equal(0);
-        expect([subject artworksShouldShowInstallShots:@[artwork] context:nil]).to.beFalsy();
+        expect([subject artworksShouldShowInstallShots:@[ artwork ] context:nil]).to.beFalsy();
     });
 });
 
@@ -188,7 +192,7 @@ describe(@"document containers", ^{
         Artist *artist = [Artist objectInContext:context];
         artist.documents = [NSSet setWithObject:document];
         Artwork *artwork = [Artwork objectInContext:context];
-        artwork.artist = artist;
+        artwork.artists = [NSSet setWithObject:artist];
 
         // A show
         Show *show = [Show objectInContext:context];
@@ -196,8 +200,8 @@ describe(@"document containers", ^{
         Artwork *artwork2 = [Artwork objectInContext:context];
         show.artworks = [NSSet setWithObject:artwork2];
 
-        artworks = @[artwork, artwork2];
-        documents = @[document];
+        artworks = @[ artwork, artwork2 ];
+        documents = @[ document ];
 
         NSArray *unsorted = [subject arrayOfRelatedShowDocumentContainersForArtworks:artworks documents:documents];
         expect(unsorted).to.contain(artist);

--- a/Classes/Artwork/Paging/ARArtworkSetViewController.m
+++ b/Classes/Artwork/Paging/ARArtworkSetViewController.m
@@ -106,7 +106,7 @@
     [super viewWillAppear:animated];
     [self setupArtworkToolbar];
     [(ARNavigationController *)self.navigationController setBarTransparency:YES];
-    [ARAnalytics event:ARArtworkViewEvent withProperties:@{ @"artist" : self.currentArtwork.artist.name ?: @"" }];
+    [ARAnalytics event:ARArtworkViewEvent withProperties:@{ @"artist" : self.currentArtwork.artistDisplayString ?: @"" }];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -189,7 +189,7 @@
 
 - (void)viewInRoom:(id)sender
 {
-    [ARAnalytics event:ARArtworkViewInRoomEvent withProperties:@{ @"artist" : self.currentArtwork.artist.name ?: @"" }];
+    [ARAnalytics event:ARArtworkViewInRoomEvent withProperties:@{ @"artist" : self.currentArtwork.artistDisplayString ?: @"" }];
 
     [self dismissPopoversAnimated:YES];
     Artwork *artwork = [self currentArtwork];
@@ -349,8 +349,7 @@
         case MFMailComposeResultCancelled:
             [ARAnalytics event:AREmailCancelledEvent];
             break;
-        default:
-            ;
+        default:;
     }
 
     [self dismissViewControllerAnimated:YES completion:nil];

--- a/Classes/Categories/NSAttributedString+Artsy.m
+++ b/Classes/Categories/NSAttributedString+Artsy.m
@@ -28,9 +28,7 @@
 
 + (NSAttributedString *)artistStringForArtwork:(Artwork *)artwork
 {
-    if (artwork.artist.name == nil) return nil;
-
-    return [[NSAttributedString alloc] initWithString:artwork.artist.name.uppercaseString attributes:@{
+    return [[NSAttributedString alloc] initWithString:artwork.artistDisplayString.uppercaseString attributes:@{
         NSFontAttributeName : [UIFont sansSerifFontWithSize:16]
     }];
 }

--- a/Classes/Constants/ARFeedKeys.h
+++ b/Classes/Constants/ARFeedKeys.h
@@ -13,6 +13,7 @@ extern NSString *const ARFeedSlugKey;
 extern NSString *const ARFeedTitleKey;
 extern NSString *const ARFeedDisplayTitleKey;
 extern NSString *const ARFeedArtistKey;
+extern NSString *const ARFeedArtistsKey;
 extern NSString *const ARFeedNameKey;
 extern NSString *const ARFeedCategoryKey;
 extern NSString *const ARFeedMediumKey;

--- a/Classes/Constants/ARFeedKeys.m
+++ b/Classes/Constants/ARFeedKeys.m
@@ -13,6 +13,7 @@ NSString *const ARFeedSlugKey = @"slug";
 NSString *const ARFeedTitleKey = @"title";
 NSString *const ARFeedDisplayTitleKey = @"display";
 NSString *const ARFeedArtistKey = @"artist";
+NSString *const ARFeedArtistsKey = @"artists";
 
 NSString *const ARFeedNameKey = @"name";
 NSString *const ARFeedCategoryKey = @"category";

--- a/Classes/Contexts/Emailing Artworks/Controllers/ARModernEmailArtworksViewControllerDataSource.m
+++ b/Classes/Contexts/Emailing Artworks/Controllers/ARModernEmailArtworksViewControllerDataSource.m
@@ -1,5 +1,6 @@
 
 
+
 @interface NSArray (ORAnyExtends)
 
 - (BOOL)anyObjectsMatch:(BOOL (^)(id object))block;
@@ -47,8 +48,10 @@
                 return show.sortedDocuments.count > 0;
             }]];
 
-            if (artwork.artist.sortedDocuments.count) {
-                [allContainers addObject:artwork.artist];
+            for (Artist *artist in artwork.artists) {
+                if (artist.sortedDocuments.count) {
+                    [allContainers addObject:artist];
+                }
             }
 
             return allContainers;
@@ -93,9 +96,9 @@
 - (BOOL)artworksShouldShowBackendPrice:(NSArray *)artworks
 {
     return [artworks anyObjectsMatch:^BOOL(Artwork *artwork) {
-        return  artwork.backendPrice &&
-                artwork.backendPrice.length > 1 &&
-               ![artwork.backendPrice isEqualToString:artwork.displayPrice];
+        return artwork.backendPrice &&
+            artwork.backendPrice.length > 1 &&
+            ![artwork.backendPrice isEqualToString:artwork.displayPrice];
     }];
 }
 

--- a/Classes/Controllers/Login & Setup/Sync/ARSyncViewController.m
+++ b/Classes/Controllers/Login & Setup/Sync/ARSyncViewController.m
@@ -83,7 +83,7 @@
 
 - (void)showAdminSyncVC:(UITapGestureRecognizer *)tapGesture
 {
-    if (self.navigationController.topViewController != self) {
+    if (tapGesture.state != UIGestureRecognizerStateRecognized) {
         return;
     }
 

--- a/Classes/Controllers/Login & Setup/Sync/ARSyncViewController.m
+++ b/Classes/Controllers/Login & Setup/Sync/ARSyncViewController.m
@@ -71,7 +71,7 @@
     _appearedDate = [NSDate date];
 
     if ([user isAdmin]) {
-        UILongPressGestureRecognizer *adminTapGesture = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(showAdminSyncVC)];
+        UILongPressGestureRecognizer *adminTapGesture = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(showAdminSyncVC:)];
         [self.view addGestureRecognizer:adminTapGesture];
     }
 }
@@ -81,8 +81,12 @@
     _partnerName = [name uppercaseString];
 }
 
-- (void)showAdminSyncVC
+- (void)showAdminSyncVC:(UITapGestureRecognizer *)tapGesture
 {
+    if (self.navigationController.topViewController != self) {
+        return;
+    }
+
     id syncVC = [[ARSyncAdminViewController alloc] init];
     [self.navigationController pushViewController:syncVC animated:YES];
 }

--- a/Classes/Controllers/Navigation Controllers/ARNavigationController.m
+++ b/Classes/Controllers/Navigation Controllers/ARNavigationController.m
@@ -137,7 +137,6 @@ static ARNavigationController *sharedInstance = nil;
 {
     [_searchViewController reset];
     [_searchPopoverController dismissPopoverAnimated:NO];
-
 }
 
 - (void)pushViewController:(UIViewController *)viewController animated:(BOOL)animated
@@ -204,7 +203,7 @@ static ARNavigationController *sharedInstance = nil;
 
 - (void)searchViewController:(ARSearchViewController *)aController didSelectArtwork:(Artwork *)artwork
 {
-    [ARAnalytics event:ARSearchSelectArtworkEvent withProperties:@{ @"artist" : artwork.artist.name }];
+    [ARAnalytics event:ARSearchSelectArtworkEvent withProperties:@{ @"artist" : artwork.artistDisplayString }];
     [[ARSwitchBoard sharedSwitchboard] jumpToArtworkViewController:artwork context:[CoreDataManager mainManagedObjectContext]];
 }
 

--- a/Classes/Controllers/Settings/ARSettingsMenuViewController.m
+++ b/Classes/Controllers/Settings/ARSettingsMenuViewController.m
@@ -190,12 +190,6 @@ typedef NS_ENUM(NSInteger, ARSettingsAlertViewButtonIndex) {
     [(ARSettingsSplitViewController *)self.splitViewController exitSettingsPanel];
 }
 
-- (IBAction)ogSettingsButtonPressed:(id)sender
-{
-    [self.viewModel switchToOriginalSettings];
-    [self exitSettingsPanel];
-}
-
 - (BOOL)prefersStatusBarHidden
 {
     return YES;

--- a/Classes/Controllers/Settings/ARSettingsMenuViewModel.h
+++ b/Classes/Controllers/Settings/ARSettingsMenuViewModel.h
@@ -26,7 +26,4 @@
 /// Logs out via ARAppDelegate
 - (void)logout;
 
-/// Deprecated once old settings are removed
-- (void)switchToOriginalSettings;
-
 @end

--- a/Classes/Models/Album.m
+++ b/Classes/Models/Album.m
@@ -67,9 +67,8 @@
 {
     NSMutableSet *artists = [NSMutableSet set];
     [self.artworks each:^(Artwork *artwork) {
-        if (!artwork.artist) return;
-
-        [artists addObject:artwork.artist];
+        NSSet *artworkArtists = artwork.artists.count ? artwork.artists : [NSSet setWithObject:artwork.artist];
+        [artists addObjectsFromArray:artworkArtists.allObjects];
     }];
     self.artists = artists;
 }

--- a/Classes/Models/Album.m
+++ b/Classes/Models/Album.m
@@ -67,8 +67,7 @@
 {
     NSMutableSet *artists = [NSMutableSet set];
     [self.artworks each:^(Artwork *artwork) {
-        NSSet *artworkArtists = artwork.artists.count ? artwork.artists : [NSSet setWithObject:artwork.artist];
-        [artists addObjectsFromArray:artworkArtists.allObjects];
+        [artists addObjectsFromArray:artwork.artists.allObjects];
     }];
     self.artists = artists;
 }

--- a/Classes/Models/Artist.h
+++ b/Classes/Models/Artist.h
@@ -8,7 +8,8 @@
 @class Image, Document, Show, Album, Artwork;
 
 
-@interface Artist : _Artist <ARGridViewItem, ARDocumentContainer, ARArtworkContainer> {
+@interface Artist : _Artist <ARGridViewItem, ARDocumentContainer, ARArtworkContainer>
+{
     NSDateFormatter *dateFormatter;
 }
 
@@ -25,5 +26,9 @@
 - (NSFetchRequest *)showsFeaturingArtistFetchRequest;
 
 - (NSFetchRequest *)albumsFeaturingArtistFetchRequest;
+
+/// Sets up a default artist for ambiguous works with no artists,
+/// in the future this should take into account cultural markers
++ (Artist *)findOrCreateUnknownArtistInContext:(NSManagedObjectContext *)context;
 
 @end

--- a/Classes/Models/Artist.m
+++ b/Classes/Models/Artist.m
@@ -24,6 +24,8 @@
 
 - (void)updateWithDictionary:(NSDictionary *)aDictionary
 {
+    [super updateWithDictionary:aDictionary];
+
     self.name = [aDictionary onlyStringForKey:ARFeedNameKey];
     self.years = [aDictionary onlyStringForKey:ARFeedYearsKey];
 
@@ -73,8 +75,7 @@
 
 - (NSFetchRequest *)artworksFetchRequestSortedBy:(ARArtworkSortOrder)order
 {
-    //    NSPredicate *scopePredicate = [NSPredicate predicateWithFormat:@"SUBQUERY(artists, $artist, $artist.slug == %@) .@count > 0", self.slug];
-    NSPredicate *scopePredicate = [NSPredicate predicateWithFormat:@"ANY artists.slug == %@", self.slug];
+    NSPredicate *scopePredicate = [NSPredicate predicateWithFormat:@"ANY artists == %@", self];
     NSFetchRequest *allArtworksRequest = [NSFetchRequest ar_allArtworksOfArtworkContainerWithSelfPredicate:scopePredicate inContext:self.managedObjectContext defaults:NSUserDefaults.standardUserDefaults];
 
     allArtworksRequest.sortDescriptors = [ARSortOrderHost sortDescriptorsWithoutArtistWithOrder:order];

--- a/Classes/Models/Artist.m
+++ b/Classes/Models/Artist.m
@@ -66,7 +66,7 @@
                                                   withEntityName:@"Artwork"
                                                        inContext:self.managedObjectContext
                                                           saving:NO];
-        NSSet *artworksSet = [[NSSet alloc] initWithArray:artworks];
+        NSSet *artworksSet = [NSSet setWithArray:artworks];
         [self addArtworks:artworksSet];
     }
 }
@@ -231,6 +231,19 @@
     request.predicate = [NSPredicate predicateWithFormat:@"ANY artists == %@", self];
     request.sortDescriptors = @[ [NSSortDescriptor sortDescriptorWithKey:@"name" ascending:YES] ];
     return request;
+}
+
++ (Artist *)findOrCreateUnknownArtistInContext:(NSManagedObjectContext *)context
+{
+    Artist *unknownArtist = [Artist findFirstByAttribute:@"slug" withValue:@"unknown-artist" inContext:context];
+    if (!unknownArtist) {
+        unknownArtist = [Artist createInContext:context];
+        unknownArtist.displayName = @"Unknown Artist";
+        unknownArtist.slug = @"unknown-artist";
+        unknownArtist.orderingKey = @"Unknown Artist";
+        unknownArtist.name = @"Unknown Artist";
+    }
+    return unknownArtist;
 }
 
 @end

--- a/Classes/Models/Artist.m
+++ b/Classes/Models/Artist.m
@@ -73,7 +73,8 @@
 
 - (NSFetchRequest *)artworksFetchRequestSortedBy:(ARArtworkSortOrder)order
 {
-    NSPredicate *scopePredicate = [NSPredicate predicateWithFormat:@"artist.slug == %@", self.slug];
+    //    NSPredicate *scopePredicate = [NSPredicate predicateWithFormat:@"SUBQUERY(artists, $artist, $artist.slug == %@) .@count > 0", self.slug];
+    NSPredicate *scopePredicate = [NSPredicate predicateWithFormat:@"ANY artists.slug == %@", self.slug];
     NSFetchRequest *allArtworksRequest = [NSFetchRequest ar_allArtworksOfArtworkContainerWithSelfPredicate:scopePredicate inContext:self.managedObjectContext defaults:NSUserDefaults.standardUserDefaults];
 
     allArtworksRequest.sortDescriptors = [ARSortOrderHost sortDescriptorsWithoutArtistWithOrder:order];

--- a/Classes/Models/Artwork.h
+++ b/Classes/Models/Artwork.h
@@ -10,6 +10,9 @@
 /// Use `artists` instead, keeping around to ensure backwards compatability.
 - (Artist *)artist DEPRECATED_ATTRIBUTE;
 
+/// Use `editionSets` instead
+- (NSString *)editions DEPRECATED_ATTRIBUTE;
+
 - (NSArray *)sortedImages;
 
 - (BOOL)hasAdditionalInfo;

--- a/Classes/Models/Artwork.h
+++ b/Classes/Models/Artwork.h
@@ -21,6 +21,9 @@
 
 - (NSString *)titleForEmail;
 
+/// Display string for the titles of an Artwork, can handle multiple artists
+- (NSString *)artistDisplayString;
+
 /// Price used by Partner (may or may not be available to the public)
 - (NSString *)internalPrice;
 

--- a/Classes/Models/Artwork.h
+++ b/Classes/Models/Artwork.h
@@ -7,6 +7,9 @@
 
 @interface Artwork : _Artwork <ARGridViewItem, ARMultipleSelectionItem>
 
+/// Use `artists` instead, keeping around to ensure backwards compatability.
+- (Artist *)artist DEPRECATED_ATTRIBUTE;
+
 - (NSArray *)sortedImages;
 
 - (BOOL)hasAdditionalInfo;

--- a/Classes/Models/Artwork.m
+++ b/Classes/Models/Artwork.m
@@ -18,16 +18,10 @@ static const int NumberOfCharactersInArtworkTitleBeforeCrop = 20;
 {
     self.title = [aDictionary onlyStringForKey:ARFeedTitleKey];
 
-    if ([aDictionary onlyArrayForKey:ARFeedArtistsKey].count) {
+    if ([aDictionary onlyArrayForKey:ARFeedArtistsKey].count > 0) {
         NSArray<Artist *> *artists = [ARFeedTranslator addOrUpdateObjects:[aDictionary onlyArrayForKey:ARFeedArtistsKey] withEntityName:@"Artist" inContext:self.managedObjectContext saving:NO];
         self.artists = [NSSet setWithArray:artists];
-        //
-        //    if ([aDictionary objectForKeyNotNull:ARFeedArtistKey]) {
-        //        Artist *artist = (Artist *)[ARFeedTranslator addOrUpdateObject:[aDictionary onlyDictionaryForKey:ARFeedArtistKey]
-        //                                                        withEntityName:@"Artist"
-        //                                                             inContext:self.managedObjectContext
-        //                                                                saving:NO];
-        //        self.artist = artist;
+
     } else {
         // Create an unknown artist.
         Artist *unknownArtist = [Artist findOrCreateUnknownArtistInContext:self.managedObjectContext];
@@ -286,8 +280,7 @@ static const int NumberOfCharactersInArtworkTitleBeforeCrop = 20;
 
 - (NSString *)artistDisplayString
 {
-    NSSet *artists = self.artists.count ? self.artists : [NSSet setWithObject:self.artist];
-    return [[artists map:^id(Artist *artist) {
+    return [[self.artists map:^id(Artist *artist) {
         return artist.presentableName;
     }] join:@", "];
 }

--- a/Classes/Models/Artwork.m
+++ b/Classes/Models/Artwork.m
@@ -97,10 +97,6 @@ static const int NumberOfCharactersInArtworkTitleBeforeCrop = 20;
     self.series = [aDictionary onlyStringForKey:ARFeedSeriesKey];
     self.inventoryID = [aDictionary onlyStringForKey:ARFeedInventoryIDKey];
     self.confidentialNotes = [aDictionary onlyStringForKey:ARFeedConfidentialNotesKey];
-
-    if ([aDictionary[ARFeedArtworkEditionSetsKey] count]) {
-        //        self.editions = [aDictionartworkary[ARFeedArtworkEditionSetsKey][0] onlyStringForKey:ARFeedArtworkEditionsKey];
-    }
 }
 
 - (void)convertDimensionsToAmericanSystemOfMeasurement
@@ -288,7 +284,7 @@ static NSSortDescriptor *ARSortDisplayDescriptor;
 
     return [[[self.artists sortedArrayUsingDescriptors:@[ ARSortDisplayDescriptor ]] map:^id(Artist *artist) {
         return artist.presentableName;
-    }] join:@", "];
+    }] join:@", "] ?: @"";
 }
 
 + (NSFetchedResultsController *)allArtworksInContext:(NSManagedObjectContext *)context
@@ -297,9 +293,17 @@ static NSSortDescriptor *ARSortDisplayDescriptor;
     return [[NSFetchedResultsController alloc] initWithFetchRequest:request managedObjectContext:context sectionNameKeyPath:nil cacheName:nil];
 }
 
+/// To deprecate a method you need to have an implementation
+
 - (Artist *)artist
 {
     return [super artist];
+}
+
+
+- (NSString *)editions
+{
+    return [super editions];
 }
 
 @end

--- a/Classes/Models/Artwork.m
+++ b/Classes/Models/Artwork.m
@@ -11,7 +11,7 @@ static const int NumberOfCharactersInArtworkTitleBeforeCrop = 20;
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"Artwork : %@ ( by %@ )", self.title, self.artist.gridTitle];
+    return [NSString stringWithFormat:@"Artwork : %@ ( by %@ )", self.title, self.artistDisplayString];
 }
 
 - (void)updateWithDictionary:(NSDictionary *)aDictionary
@@ -37,7 +37,7 @@ static const int NumberOfCharactersInArtworkTitleBeforeCrop = 20;
                 [images addObject:imageDictWithID];
             } else {
                 [ARAnalytics event:@"Error - no ID for images on Artwork" withProperties:@{ @"artwork" : self.title,
-                                                                                            @"artist" : self.artist.searchDisplayName }];
+                                                                                            @"artist" : self.artistDisplayString }];
             }
         }
 
@@ -209,7 +209,7 @@ static const int NumberOfCharactersInArtworkTitleBeforeCrop = 20;
 
 - (NSString *)gridTitle
 {
-    return self.artist.gridTitle;
+    return self.artistDisplayString;
 }
 
 - (NSUInteger)collectionSize
@@ -278,9 +278,15 @@ static const int NumberOfCharactersInArtworkTitleBeforeCrop = 20;
     return title;
 }
 
+static NSSortDescriptor *ARSortDisplayDescriptor;
+
 - (NSString *)artistDisplayString
 {
-    return [[self.artists map:^id(Artist *artist) {
+    if (!ARSortDisplayDescriptor) {
+        ARSortDisplayDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"orderingKey" ascending:YES];
+    }
+
+    return [[[self.artists sortedArrayUsingDescriptors:@[ ARSortDisplayDescriptor ]] map:^id(Artist *artist) {
         return artist.presentableName;
     }] join:@", "];
 }
@@ -289,6 +295,11 @@ static const int NumberOfCharactersInArtworkTitleBeforeCrop = 20;
 {
     NSFetchRequest *request = [self.class requestAllSortedBy:@keypath(Artwork.new, title) ascending:YES inContext:context];
     return [[NSFetchedResultsController alloc] initWithFetchRequest:request managedObjectContext:context sectionNameKeyPath:nil cacheName:nil];
+}
+
+- (Artist *)artist
+{
+    return [super artist];
 }
 
 @end

--- a/Classes/Models/Artwork.m
+++ b/Classes/Models/Artwork.m
@@ -18,21 +18,20 @@ static const int NumberOfCharactersInArtworkTitleBeforeCrop = 20;
 {
     self.title = [aDictionary onlyStringForKey:ARFeedTitleKey];
 
-    if ([aDictionary onlyArrayForKey:ARFeedArtistsKey]) {
+    if ([aDictionary onlyArrayForKey:ARFeedArtistsKey].count) {
         NSArray<Artist *> *artists = [ARFeedTranslator addOrUpdateObjects:[aDictionary onlyArrayForKey:ARFeedArtistsKey] withEntityName:@"Artist" inContext:self.managedObjectContext saving:NO];
         self.artists = [NSSet setWithArray:artists];
-    }
-
-    if ([aDictionary objectForKeyNotNull:ARFeedArtistKey]) {
-        Artist *artist = (Artist *)[ARFeedTranslator addOrUpdateObject:[aDictionary onlyDictionaryForKey:ARFeedArtistKey]
-                                                        withEntityName:@"Artist"
-                                                             inContext:self.managedObjectContext
-                                                                saving:NO];
-        self.artist = artist;
+        //
+        //    if ([aDictionary objectForKeyNotNull:ARFeedArtistKey]) {
+        //        Artist *artist = (Artist *)[ARFeedTranslator addOrUpdateObject:[aDictionary onlyDictionaryForKey:ARFeedArtistKey]
+        //                                                        withEntityName:@"Artist"
+        //                                                             inContext:self.managedObjectContext
+        //                                                                saving:NO];
+        //        self.artist = artist;
     } else {
         // Create an unknown artist.
         Artist *unknownArtist = [Artist findOrCreateUnknownArtistInContext:self.managedObjectContext];
-        self.artist = unknownArtist;
+        self.artists = [NSSet setWithObject:unknownArtist];
     }
 
     if ([aDictionary onlyArrayForKey:ARFeedImagesKey]) {

--- a/Classes/Models/Generated/_Album.h
+++ b/Classes/Models/Generated/_Album.h
@@ -1,31 +1,17 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to Album.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "ARManagedObject.h"
 
-extern const struct AlbumAttributes {
-    __unsafe_unretained NSString *createdAt;
-    __unsafe_unretained NSString *editable;
-    __unsafe_unretained NSString *hasBeenEdited;
-    __unsafe_unretained NSString *isPrivate;
-    __unsafe_unretained NSString *name;
-    __unsafe_unretained NSString *slug;
-    __unsafe_unretained NSString *sortKey;
-    __unsafe_unretained NSString *summary;
-    __unsafe_unretained NSString *type;
-    __unsafe_unretained NSString *updatedAt;
-} AlbumAttributes;
-
-extern const struct AlbumRelationships {
-    __unsafe_unretained NSString *artists;
-    __unsafe_unretained NSString *artworks;
-    __unsafe_unretained NSString *cover;
-    __unsafe_unretained NSString *documents;
-} AlbumRelationships;
-
-extern const struct AlbumUserInfo {
-} AlbumUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 @class Artist;
 @class Artwork;
@@ -33,79 +19,170 @@ extern const struct AlbumUserInfo {
 @class Document;
 
 
-@interface AlbumID : ARManagedObjectID {
+@interface AlbumID : NSManagedObjectID
+{
 }
 @end
 
 
-@interface _Album : ARManagedObject {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _Album : ARManagedObject
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (AlbumID *)objectID;
+@property (nonatomic, readonly, strong) AlbumID *objectID;
 
-@property (nonatomic, strong) NSDate *createdAt;
-@property (nonatomic, strong) NSNumber *editable;
-@property (nonatomic, strong) NSNumber *hasBeenEdited;
-@property (nonatomic, strong) NSNumber *isPrivate;
-@property (nonatomic, strong) NSString *name;
+@property (nonatomic, strong, nullable) NSDate *createdAt;
+
+@property (nonatomic, strong, nullable) NSNumber *editable;
+
+@property (atomic) BOOL editableValue;
+- (BOOL)editableValue;
+- (void)setEditableValue:(BOOL)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *hasBeenEdited;
+
+@property (atomic) BOOL hasBeenEditedValue;
+- (BOOL)hasBeenEditedValue;
+- (void)setHasBeenEditedValue:(BOOL)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *isPrivate;
+
+@property (atomic) BOOL isPrivateValue;
+- (BOOL)isPrivateValue;
+- (void)setIsPrivateValue:(BOOL)value_;
+
+@property (nonatomic, strong, nullable) NSString *name;
+
 @property (nonatomic, strong) NSString *slug;
-@property (nonatomic, strong) NSNumber *sortKey;
-@property (nonatomic, strong) NSString *summary;
-@property (nonatomic, strong) NSString *type;
-@property (nonatomic, strong) NSDate *updatedAt;
 
-@property (nonatomic, strong) NSSet *artists;
-- (NSMutableSet *)artistsSet;
+@property (nonatomic, strong, nullable) NSNumber *sortKey;
 
-@property (nonatomic, strong) NSSet *artworks;
-- (NSMutableSet *)artworksSet;
-@property (nonatomic, strong) Image *cover;
+@property (atomic) int16_t sortKeyValue;
+- (int16_t)sortKeyValue;
+- (void)setSortKeyValue:(int16_t)value_;
 
-@property (nonatomic, strong) NSSet *documents;
-- (NSMutableSet *)documentsSet;
+@property (nonatomic, strong, nullable) NSString *summary;
 
+@property (nonatomic, strong, nullable) NSString *type;
+
+@property (nonatomic, strong, nullable) NSDate *updatedAt;
+
+@property (nonatomic, strong, nullable) NSSet<Artist *> *artists;
+- (nullable NSMutableSet<Artist *> *)artistsSet;
+
+@property (nonatomic, strong, nullable) NSSet<Artwork *> *artworks;
+- (nullable NSMutableSet<Artwork *> *)artworksSet;
+
+@property (nonatomic, strong, nullable) Image *cover;
+
+@property (nonatomic, strong, nullable) NSSet<Document *> *documents;
+- (nullable NSMutableSet<Document *> *)documentsSet;
 
 @end
 
 
 @interface _Album (ArtistsCoreDataGeneratedAccessors)
-- (void)addArtists:(NSSet *)value_;
-- (void)removeArtists:(NSSet *)value_;
+- (void)addArtists:(NSSet<Artist *> *)value_;
+- (void)removeArtists:(NSSet<Artist *> *)value_;
 - (void)addArtistsObject:(Artist *)value_;
 - (void)removeArtistsObject:(Artist *)value_;
+
 @end
 
 
 @interface _Album (ArtworksCoreDataGeneratedAccessors)
-- (void)addArtworks:(NSSet *)value_;
-- (void)removeArtworks:(NSSet *)value_;
+- (void)addArtworks:(NSSet<Artwork *> *)value_;
+- (void)removeArtworks:(NSSet<Artwork *> *)value_;
 - (void)addArtworksObject:(Artwork *)value_;
 - (void)removeArtworksObject:(Artwork *)value_;
+
 @end
 
 
 @interface _Album (DocumentsCoreDataGeneratedAccessors)
-- (void)addDocuments:(NSSet *)value_;
-- (void)removeDocuments:(NSSet *)value_;
+- (void)addDocuments:(NSSet<Document *> *)value_;
+- (void)removeDocuments:(NSSet<Document *> *)value_;
 - (void)addDocumentsObject:(Document *)value_;
 - (void)removeDocumentsObject:(Document *)value_;
+
 @end
 
 
 @interface _Album (CoreDataGeneratedPrimitiveAccessors)
 
-- (NSMutableSet *)primitiveArtists;
-- (void)setPrimitiveArtists:(NSMutableSet *)value;
+- (NSDate *)primitiveCreatedAt;
+- (void)setPrimitiveCreatedAt:(NSDate *)value;
 
-- (NSMutableSet *)primitiveArtworks;
-- (void)setPrimitiveArtworks:(NSMutableSet *)value;
+- (NSNumber *)primitiveEditable;
+- (void)setPrimitiveEditable:(NSNumber *)value;
+
+- (BOOL)primitiveEditableValue;
+- (void)setPrimitiveEditableValue:(BOOL)value_;
+
+- (NSNumber *)primitiveHasBeenEdited;
+- (void)setPrimitiveHasBeenEdited:(NSNumber *)value;
+
+- (BOOL)primitiveHasBeenEditedValue;
+- (void)setPrimitiveHasBeenEditedValue:(BOOL)value_;
+
+- (NSNumber *)primitiveIsPrivate;
+- (void)setPrimitiveIsPrivate:(NSNumber *)value;
+
+- (BOOL)primitiveIsPrivateValue;
+- (void)setPrimitiveIsPrivateValue:(BOOL)value_;
+
+- (NSString *)primitiveName;
+- (void)setPrimitiveName:(NSString *)value;
+
+- (NSString *)primitiveSlug;
+- (void)setPrimitiveSlug:(NSString *)value;
+
+- (NSNumber *)primitiveSortKey;
+- (void)setPrimitiveSortKey:(NSNumber *)value;
+
+- (int16_t)primitiveSortKeyValue;
+- (void)setPrimitiveSortKeyValue:(int16_t)value_;
+
+- (NSString *)primitiveSummary;
+- (void)setPrimitiveSummary:(NSString *)value;
+
+- (NSDate *)primitiveUpdatedAt;
+- (void)setPrimitiveUpdatedAt:(NSDate *)value;
+
+- (NSMutableSet<Artist *> *)primitiveArtists;
+- (void)setPrimitiveArtists:(NSMutableSet<Artist *> *)value;
+
+- (NSMutableSet<Artwork *> *)primitiveArtworks;
+- (void)setPrimitiveArtworks:(NSMutableSet<Artwork *> *)value;
 
 - (Image *)primitiveCover;
 - (void)setPrimitiveCover:(Image *)value;
 
-- (NSMutableSet *)primitiveDocuments;
-- (void)setPrimitiveDocuments:(NSMutableSet *)value;
+- (NSMutableSet<Document *> *)primitiveDocuments;
+- (void)setPrimitiveDocuments:(NSMutableSet<Document *> *)value;
 
 @end
+
+
+@interface AlbumAttributes : NSObject
++ (NSString *)createdAt;
++ (NSString *)editable;
++ (NSString *)hasBeenEdited;
++ (NSString *)isPrivate;
++ (NSString *)name;
++ (NSString *)slug;
++ (NSString *)sortKey;
++ (NSString *)summary;
++ (NSString *)type;
++ (NSString *)updatedAt;
+@end
+
+
+@interface AlbumRelationships : NSObject
++ (NSString *)artists;
++ (NSString *)artworks;
++ (NSString *)cover;
++ (NSString *)documents;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_Album.m
+++ b/Classes/Models/Generated/_Album.m
@@ -3,28 +3,6 @@
 
 #import "_Album.h"
 
-const struct AlbumAttributes AlbumAttributes = {
-    .createdAt = @"createdAt",
-    .editable = @"editable",
-    .hasBeenEdited = @"hasBeenEdited",
-    .isPrivate = @"isPrivate",
-    .name = @"name",
-    .slug = @"slug",
-    .sortKey = @"sortKey",
-    .summary = @"summary",
-    .type = @"type",
-    .updatedAt = @"updatedAt",
-};
-
-const struct AlbumRelationships AlbumRelationships = {
-    .artists = @"artists",
-    .artworks = @"artworks",
-    .cover = @"cover",
-    .documents = @"documents",
-};
-
-const struct AlbumUserInfo AlbumUserInfo = {};
-
 
 @implementation AlbumID
 @end
@@ -32,7 +10,7 @@ const struct AlbumUserInfo AlbumUserInfo = {};
 
 @implementation _Album
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"Album" inManagedObjectContext:moc_];
@@ -54,46 +32,242 @@ const struct AlbumUserInfo AlbumUserInfo = {};
     return (AlbumID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    if ([key isEqualToString:@"editableValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"editable"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"hasBeenEditedValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"hasBeenEdited"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"isPrivateValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"isPrivate"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"sortKeyValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"sortKey"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+
+    return keyPaths;
+}
 
 @dynamic createdAt;
+
 @dynamic editable;
+
+- (BOOL)editableValue
+{
+    NSNumber *result = [self editable];
+    return [result boolValue];
+}
+
+- (void)setEditableValue:(BOOL)value_
+{
+    [self setEditable:@(value_)];
+}
+
+- (BOOL)primitiveEditableValue
+{
+    NSNumber *result = [self primitiveEditable];
+    return [result boolValue];
+}
+
+- (void)setPrimitiveEditableValue:(BOOL)value_
+{
+    [self setPrimitiveEditable:@(value_)];
+}
+
 @dynamic hasBeenEdited;
+
+- (BOOL)hasBeenEditedValue
+{
+    NSNumber *result = [self hasBeenEdited];
+    return [result boolValue];
+}
+
+- (void)setHasBeenEditedValue:(BOOL)value_
+{
+    [self setHasBeenEdited:@(value_)];
+}
+
+- (BOOL)primitiveHasBeenEditedValue
+{
+    NSNumber *result = [self primitiveHasBeenEdited];
+    return [result boolValue];
+}
+
+- (void)setPrimitiveHasBeenEditedValue:(BOOL)value_
+{
+    [self setPrimitiveHasBeenEdited:@(value_)];
+}
+
 @dynamic isPrivate;
+
+- (BOOL)isPrivateValue
+{
+    NSNumber *result = [self isPrivate];
+    return [result boolValue];
+}
+
+- (void)setIsPrivateValue:(BOOL)value_
+{
+    [self setIsPrivate:@(value_)];
+}
+
+- (BOOL)primitiveIsPrivateValue
+{
+    NSNumber *result = [self primitiveIsPrivate];
+    return [result boolValue];
+}
+
+- (void)setPrimitiveIsPrivateValue:(BOOL)value_
+{
+    [self setPrimitiveIsPrivate:@(value_)];
+}
+
 @dynamic name;
+
 @dynamic slug;
+
 @dynamic sortKey;
+
+- (int16_t)sortKeyValue
+{
+    NSNumber *result = [self sortKey];
+    return [result shortValue];
+}
+
+- (void)setSortKeyValue:(int16_t)value_
+{
+    [self setSortKey:@(value_)];
+}
+
+- (int16_t)primitiveSortKeyValue
+{
+    NSNumber *result = [self primitiveSortKey];
+    return [result shortValue];
+}
+
+- (void)setPrimitiveSortKeyValue:(int16_t)value_
+{
+    [self setPrimitiveSortKey:@(value_)];
+}
+
 @dynamic summary;
+
 @dynamic type;
+
 @dynamic updatedAt;
 
-
 @dynamic artists;
-- (NSMutableSet *)artistsSet
+
+- (NSMutableSet<Artist *> *)artistsSet
 {
     [self willAccessValueForKey:@"artists"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"artists"];
+
+    NSMutableSet<Artist *> *result = (NSMutableSet<Artist *> *)[self mutableSetValueForKey:@"artists"];
+
     [self didAccessValueForKey:@"artists"];
     return result;
 }
 
 @dynamic artworks;
-- (NSMutableSet *)artworksSet
+
+- (NSMutableSet<Artwork *> *)artworksSet
 {
     [self willAccessValueForKey:@"artworks"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"artworks"];
+
+    NSMutableSet<Artwork *> *result = (NSMutableSet<Artwork *> *)[self mutableSetValueForKey:@"artworks"];
+
     [self didAccessValueForKey:@"artworks"];
     return result;
 }
 
 @dynamic cover;
+
 @dynamic documents;
-- (NSMutableSet *)documentsSet
+
+- (NSMutableSet<Document *> *)documentsSet
 {
     [self willAccessValueForKey:@"documents"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"documents"];
+
+    NSMutableSet<Document *> *result = (NSMutableSet<Document *> *)[self mutableSetValueForKey:@"documents"];
+
     [self didAccessValueForKey:@"documents"];
     return result;
 }
 
+@end
 
+
+@implementation AlbumAttributes
++ (NSString *)createdAt
+{
+    return @"createdAt";
+}
++ (NSString *)editable
+{
+    return @"editable";
+}
++ (NSString *)hasBeenEdited
+{
+    return @"hasBeenEdited";
+}
++ (NSString *)isPrivate
+{
+    return @"isPrivate";
+}
++ (NSString *)name
+{
+    return @"name";
+}
++ (NSString *)slug
+{
+    return @"slug";
+}
++ (NSString *)sortKey
+{
+    return @"sortKey";
+}
++ (NSString *)summary
+{
+    return @"summary";
+}
++ (NSString *)type
+{
+    return @"type";
+}
++ (NSString *)updatedAt
+{
+    return @"updatedAt";
+}
+@end
+
+
+@implementation AlbumRelationships
++ (NSString *)artists
+{
+    return @"artists";
+}
++ (NSString *)artworks
+{
+    return @"artworks";
+}
++ (NSString *)cover
+{
+    return @"cover";
+}
++ (NSString *)documents
+{
+    return @"documents";
+}
 @end

--- a/Classes/Models/Generated/_Artist.h
+++ b/Classes/Models/Generated/_Artist.h
@@ -1,41 +1,17 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to Artist.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "ARManagedObject.h"
 
-extern const struct ArtistAttributes {
-    __unsafe_unretained NSString *awards;
-    __unsafe_unretained NSString *biography;
-    __unsafe_unretained NSString *blurb;
-    __unsafe_unretained NSString *createdAt;
-    __unsafe_unretained NSString *deathDate;
-    __unsafe_unretained NSString *displayName;
-    __unsafe_unretained NSString *firstName;
-    __unsafe_unretained NSString *hometown;
-    __unsafe_unretained NSString *lastName;
-    __unsafe_unretained NSString *middleName;
-    __unsafe_unretained NSString *name;
-    __unsafe_unretained NSString *nationality;
-    __unsafe_unretained NSString *orderingKey;
-    __unsafe_unretained NSString *slug;
-    __unsafe_unretained NSString *statement;
-    __unsafe_unretained NSString *thumbnailBaseURL;
-    __unsafe_unretained NSString *updatedAt;
-    __unsafe_unretained NSString *years;
-} ArtistAttributes;
-
-extern const struct ArtistRelationships {
-    __unsafe_unretained NSString *albumsFeaturingArtist;
-    __unsafe_unretained NSString *artworks;
-    __unsafe_unretained NSString *cover;
-    __unsafe_unretained NSString *documents;
-    __unsafe_unretained NSString *installShotsFeaturingArtist;
-    __unsafe_unretained NSString *showsFeaturingArtist;
-} ArtistRelationships;
-
-extern const struct ArtistUserInfo {
-} ArtistUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 @class Album;
 @class Artwork;
@@ -45,105 +21,215 @@ extern const struct ArtistUserInfo {
 @class Show;
 
 
-@interface ArtistID : ARManagedObjectID {
+@interface ArtistID : NSManagedObjectID
+{
 }
 @end
 
 
-@interface _Artist : ARManagedObject {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _Artist : ARManagedObject
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (ArtistID *)objectID;
+@property (nonatomic, readonly, strong) ArtistID *objectID;
 
-@property (nonatomic, strong) NSString *awards;
-@property (nonatomic, strong) NSString *biography;
-@property (nonatomic, strong) NSString *blurb;
-@property (nonatomic, strong) NSDate *createdAt;
-@property (nonatomic, strong) NSDate *deathDate;
-@property (nonatomic, strong) NSString *displayName;
-@property (nonatomic, strong) NSString *firstName;
-@property (nonatomic, strong) NSString *hometown;
-@property (nonatomic, strong) NSString *lastName;
-@property (nonatomic, strong) NSString *middleName;
-@property (nonatomic, strong) NSString *name;
-@property (nonatomic, strong) NSString *nationality;
-@property (nonatomic, strong) NSString *orderingKey;
+@property (nonatomic, strong, nullable) NSString *awards;
+
+@property (nonatomic, strong, nullable) NSString *biography;
+
+@property (nonatomic, strong, nullable) NSString *blurb;
+
+@property (nonatomic, strong, nullable) NSDate *createdAt;
+
+@property (nonatomic, strong, nullable) NSDate *deathDate;
+
+@property (nonatomic, strong, nullable) NSString *displayName;
+
+@property (nonatomic, strong, nullable) NSString *firstName;
+
+@property (nonatomic, strong, nullable) NSString *hometown;
+
+@property (nonatomic, strong, nullable) NSString *lastName;
+
+@property (nonatomic, strong, nullable) NSString *middleName;
+
+@property (nonatomic, strong, nullable) NSString *name;
+
+@property (nonatomic, strong, nullable) NSString *nationality;
+
+@property (nonatomic, strong, nullable) NSString *orderingKey;
+
 @property (nonatomic, strong) NSString *slug;
-@property (nonatomic, strong) NSString *statement;
-@property (nonatomic, strong) NSString *thumbnailBaseURL;
-@property (nonatomic, strong) NSDate *updatedAt;
-@property (nonatomic, strong) NSString *years;
 
-@property (nonatomic, strong) NSSet *albumsFeaturingArtist;
-- (NSMutableSet *)albumsFeaturingArtistSet;
+@property (nonatomic, strong, nullable) NSString *statement;
 
-@property (nonatomic, strong) NSSet *artworks;
-- (NSMutableSet *)artworksSet;
-@property (nonatomic, strong) Image *cover;
+@property (nonatomic, strong, nullable) NSString *thumbnailBaseURL;
 
-@property (nonatomic, strong) NSSet *documents;
-- (NSMutableSet *)documentsSet;
-@property (nonatomic, strong) Image *installShotsFeaturingArtist;
+@property (nonatomic, strong, nullable) NSDate *updatedAt;
 
-@property (nonatomic, strong) NSSet *showsFeaturingArtist;
-- (NSMutableSet *)showsFeaturingArtistSet;
+@property (nonatomic, strong, nullable) NSString *years;
 
+@property (nonatomic, strong, nullable) NSSet<Album *> *albumsFeaturingArtist;
+- (nullable NSMutableSet<Album *> *)albumsFeaturingArtistSet;
+
+@property (nonatomic, strong, nullable) NSSet<Artwork *> *artworks;
+- (nullable NSMutableSet<Artwork *> *)artworksSet;
+
+@property (nonatomic, strong, nullable) Image *cover;
+
+@property (nonatomic, strong, nullable) NSSet<Document *> *documents;
+- (nullable NSMutableSet<Document *> *)documentsSet;
+
+@property (nonatomic, strong, nullable) Image *installShotsFeaturingArtist;
+
+@property (nonatomic, strong, nullable) NSSet<Show *> *showsFeaturingArtist;
+- (nullable NSMutableSet<Show *> *)showsFeaturingArtistSet;
 
 @end
 
 
 @interface _Artist (AlbumsFeaturingArtistCoreDataGeneratedAccessors)
-- (void)addAlbumsFeaturingArtist:(NSSet *)value_;
-- (void)removeAlbumsFeaturingArtist:(NSSet *)value_;
+- (void)addAlbumsFeaturingArtist:(NSSet<Album *> *)value_;
+- (void)removeAlbumsFeaturingArtist:(NSSet<Album *> *)value_;
 - (void)addAlbumsFeaturingArtistObject:(Album *)value_;
 - (void)removeAlbumsFeaturingArtistObject:(Album *)value_;
+
 @end
 
 
 @interface _Artist (ArtworksCoreDataGeneratedAccessors)
-- (void)addArtworks:(NSSet *)value_;
-- (void)removeArtworks:(NSSet *)value_;
+- (void)addArtworks:(NSSet<Artwork *> *)value_;
+- (void)removeArtworks:(NSSet<Artwork *> *)value_;
 - (void)addArtworksObject:(Artwork *)value_;
 - (void)removeArtworksObject:(Artwork *)value_;
+
 @end
 
 
 @interface _Artist (DocumentsCoreDataGeneratedAccessors)
-- (void)addDocuments:(NSSet *)value_;
-- (void)removeDocuments:(NSSet *)value_;
+- (void)addDocuments:(NSSet<Document *> *)value_;
+- (void)removeDocuments:(NSSet<Document *> *)value_;
 - (void)addDocumentsObject:(Document *)value_;
 - (void)removeDocumentsObject:(Document *)value_;
+
 @end
 
 
 @interface _Artist (ShowsFeaturingArtistCoreDataGeneratedAccessors)
-- (void)addShowsFeaturingArtist:(NSSet *)value_;
-- (void)removeShowsFeaturingArtist:(NSSet *)value_;
+- (void)addShowsFeaturingArtist:(NSSet<Show *> *)value_;
+- (void)removeShowsFeaturingArtist:(NSSet<Show *> *)value_;
 - (void)addShowsFeaturingArtistObject:(Show *)value_;
 - (void)removeShowsFeaturingArtistObject:(Show *)value_;
+
 @end
 
 
 @interface _Artist (CoreDataGeneratedPrimitiveAccessors)
 
-- (NSMutableSet *)primitiveAlbumsFeaturingArtist;
-- (void)setPrimitiveAlbumsFeaturingArtist:(NSMutableSet *)value;
+- (NSString *)primitiveAwards;
+- (void)setPrimitiveAwards:(NSString *)value;
 
-- (NSMutableSet *)primitiveArtworks;
-- (void)setPrimitiveArtworks:(NSMutableSet *)value;
+- (NSString *)primitiveBiography;
+- (void)setPrimitiveBiography:(NSString *)value;
+
+- (NSString *)primitiveBlurb;
+- (void)setPrimitiveBlurb:(NSString *)value;
+
+- (NSDate *)primitiveCreatedAt;
+- (void)setPrimitiveCreatedAt:(NSDate *)value;
+
+- (NSDate *)primitiveDeathDate;
+- (void)setPrimitiveDeathDate:(NSDate *)value;
+
+- (NSString *)primitiveDisplayName;
+- (void)setPrimitiveDisplayName:(NSString *)value;
+
+- (NSString *)primitiveFirstName;
+- (void)setPrimitiveFirstName:(NSString *)value;
+
+- (NSString *)primitiveHometown;
+- (void)setPrimitiveHometown:(NSString *)value;
+
+- (NSString *)primitiveLastName;
+- (void)setPrimitiveLastName:(NSString *)value;
+
+- (NSString *)primitiveMiddleName;
+- (void)setPrimitiveMiddleName:(NSString *)value;
+
+- (NSString *)primitiveName;
+- (void)setPrimitiveName:(NSString *)value;
+
+- (NSString *)primitiveNationality;
+- (void)setPrimitiveNationality:(NSString *)value;
+
+- (NSString *)primitiveOrderingKey;
+- (void)setPrimitiveOrderingKey:(NSString *)value;
+
+- (NSString *)primitiveSlug;
+- (void)setPrimitiveSlug:(NSString *)value;
+
+- (NSString *)primitiveStatement;
+- (void)setPrimitiveStatement:(NSString *)value;
+
+- (NSString *)primitiveThumbnailBaseURL;
+- (void)setPrimitiveThumbnailBaseURL:(NSString *)value;
+
+- (NSDate *)primitiveUpdatedAt;
+- (void)setPrimitiveUpdatedAt:(NSDate *)value;
+
+- (NSString *)primitiveYears;
+- (void)setPrimitiveYears:(NSString *)value;
+
+- (NSMutableSet<Album *> *)primitiveAlbumsFeaturingArtist;
+- (void)setPrimitiveAlbumsFeaturingArtist:(NSMutableSet<Album *> *)value;
+
+- (NSMutableSet<Artwork *> *)primitiveArtworks;
+- (void)setPrimitiveArtworks:(NSMutableSet<Artwork *> *)value;
 
 - (Image *)primitiveCover;
 - (void)setPrimitiveCover:(Image *)value;
 
-- (NSMutableSet *)primitiveDocuments;
-- (void)setPrimitiveDocuments:(NSMutableSet *)value;
+- (NSMutableSet<Document *> *)primitiveDocuments;
+- (void)setPrimitiveDocuments:(NSMutableSet<Document *> *)value;
 
 - (Image *)primitiveInstallShotsFeaturingArtist;
 - (void)setPrimitiveInstallShotsFeaturingArtist:(Image *)value;
 
-- (NSMutableSet *)primitiveShowsFeaturingArtist;
-- (void)setPrimitiveShowsFeaturingArtist:(NSMutableSet *)value;
+- (NSMutableSet<Show *> *)primitiveShowsFeaturingArtist;
+- (void)setPrimitiveShowsFeaturingArtist:(NSMutableSet<Show *> *)value;
 
 @end
+
+
+@interface ArtistAttributes : NSObject
++ (NSString *)awards;
++ (NSString *)biography;
++ (NSString *)blurb;
++ (NSString *)createdAt;
++ (NSString *)deathDate;
++ (NSString *)displayName;
++ (NSString *)firstName;
++ (NSString *)hometown;
++ (NSString *)lastName;
++ (NSString *)middleName;
++ (NSString *)name;
++ (NSString *)nationality;
++ (NSString *)orderingKey;
++ (NSString *)slug;
++ (NSString *)statement;
++ (NSString *)thumbnailBaseURL;
++ (NSString *)updatedAt;
++ (NSString *)years;
+@end
+
+
+@interface ArtistRelationships : NSObject
++ (NSString *)albumsFeaturingArtist;
++ (NSString *)artworks;
++ (NSString *)cover;
++ (NSString *)documents;
++ (NSString *)installShotsFeaturingArtist;
++ (NSString *)showsFeaturingArtist;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_Artist.m
+++ b/Classes/Models/Generated/_Artist.m
@@ -3,38 +3,6 @@
 
 #import "_Artist.h"
 
-const struct ArtistAttributes ArtistAttributes = {
-    .awards = @"awards",
-    .biography = @"biography",
-    .blurb = @"blurb",
-    .createdAt = @"createdAt",
-    .deathDate = @"deathDate",
-    .displayName = @"displayName",
-    .firstName = @"firstName",
-    .hometown = @"hometown",
-    .lastName = @"lastName",
-    .middleName = @"middleName",
-    .name = @"name",
-    .nationality = @"nationality",
-    .orderingKey = @"orderingKey",
-    .slug = @"slug",
-    .statement = @"statement",
-    .thumbnailBaseURL = @"thumbnailBaseURL",
-    .updatedAt = @"updatedAt",
-    .years = @"years",
-};
-
-const struct ArtistRelationships ArtistRelationships = {
-    .albumsFeaturingArtist = @"albumsFeaturingArtist",
-    .artworks = @"artworks",
-    .cover = @"cover",
-    .documents = @"documents",
-    .installShotsFeaturingArtist = @"installShotsFeaturingArtist",
-    .showsFeaturingArtist = @"showsFeaturingArtist",
-};
-
-const struct ArtistUserInfo ArtistUserInfo = {};
-
 
 @implementation ArtistID
 @end
@@ -42,7 +10,7 @@ const struct ArtistUserInfo ArtistUserInfo = {};
 
 @implementation _Artist
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"Artist" inManagedObjectContext:moc_];
@@ -64,64 +32,203 @@ const struct ArtistUserInfo ArtistUserInfo = {};
     return (ArtistID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    return keyPaths;
+}
 
 @dynamic awards;
+
 @dynamic biography;
+
 @dynamic blurb;
+
 @dynamic createdAt;
+
 @dynamic deathDate;
+
 @dynamic displayName;
+
 @dynamic firstName;
+
 @dynamic hometown;
+
 @dynamic lastName;
+
 @dynamic middleName;
+
 @dynamic name;
+
 @dynamic nationality;
+
 @dynamic orderingKey;
+
 @dynamic slug;
+
 @dynamic statement;
+
 @dynamic thumbnailBaseURL;
+
 @dynamic updatedAt;
+
 @dynamic years;
 
-
 @dynamic albumsFeaturingArtist;
-- (NSMutableSet *)albumsFeaturingArtistSet
+
+- (NSMutableSet<Album *> *)albumsFeaturingArtistSet
 {
     [self willAccessValueForKey:@"albumsFeaturingArtist"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"albumsFeaturingArtist"];
+
+    NSMutableSet<Album *> *result = (NSMutableSet<Album *> *)[self mutableSetValueForKey:@"albumsFeaturingArtist"];
+
     [self didAccessValueForKey:@"albumsFeaturingArtist"];
     return result;
 }
 
 @dynamic artworks;
-- (NSMutableSet *)artworksSet
+
+- (NSMutableSet<Artwork *> *)artworksSet
 {
     [self willAccessValueForKey:@"artworks"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"artworks"];
+
+    NSMutableSet<Artwork *> *result = (NSMutableSet<Artwork *> *)[self mutableSetValueForKey:@"artworks"];
+
     [self didAccessValueForKey:@"artworks"];
     return result;
 }
 
 @dynamic cover;
+
 @dynamic documents;
-- (NSMutableSet *)documentsSet
+
+- (NSMutableSet<Document *> *)documentsSet
 {
     [self willAccessValueForKey:@"documents"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"documents"];
+
+    NSMutableSet<Document *> *result = (NSMutableSet<Document *> *)[self mutableSetValueForKey:@"documents"];
+
     [self didAccessValueForKey:@"documents"];
     return result;
 }
 
 @dynamic installShotsFeaturingArtist;
+
 @dynamic showsFeaturingArtist;
-- (NSMutableSet *)showsFeaturingArtistSet
+
+- (NSMutableSet<Show *> *)showsFeaturingArtistSet
 {
     [self willAccessValueForKey:@"showsFeaturingArtist"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"showsFeaturingArtist"];
+
+    NSMutableSet<Show *> *result = (NSMutableSet<Show *> *)[self mutableSetValueForKey:@"showsFeaturingArtist"];
+
     [self didAccessValueForKey:@"showsFeaturingArtist"];
     return result;
 }
 
+@end
 
+
+@implementation ArtistAttributes
++ (NSString *)awards
+{
+    return @"awards";
+}
++ (NSString *)biography
+{
+    return @"biography";
+}
++ (NSString *)blurb
+{
+    return @"blurb";
+}
++ (NSString *)createdAt
+{
+    return @"createdAt";
+}
++ (NSString *)deathDate
+{
+    return @"deathDate";
+}
++ (NSString *)displayName
+{
+    return @"displayName";
+}
++ (NSString *)firstName
+{
+    return @"firstName";
+}
++ (NSString *)hometown
+{
+    return @"hometown";
+}
++ (NSString *)lastName
+{
+    return @"lastName";
+}
++ (NSString *)middleName
+{
+    return @"middleName";
+}
++ (NSString *)name
+{
+    return @"name";
+}
++ (NSString *)nationality
+{
+    return @"nationality";
+}
++ (NSString *)orderingKey
+{
+    return @"orderingKey";
+}
++ (NSString *)slug
+{
+    return @"slug";
+}
++ (NSString *)statement
+{
+    return @"statement";
+}
++ (NSString *)thumbnailBaseURL
+{
+    return @"thumbnailBaseURL";
+}
++ (NSString *)updatedAt
+{
+    return @"updatedAt";
+}
++ (NSString *)years
+{
+    return @"years";
+}
+@end
+
+
+@implementation ArtistRelationships
++ (NSString *)albumsFeaturingArtist
+{
+    return @"albumsFeaturingArtist";
+}
++ (NSString *)artworks
+{
+    return @"artworks";
+}
++ (NSString *)cover
+{
+    return @"cover";
+}
++ (NSString *)documents
+{
+    return @"documents";
+}
++ (NSString *)installShotsFeaturingArtist
+{
+    return @"installShotsFeaturingArtist";
+}
++ (NSString *)showsFeaturingArtist
+{
+    return @"showsFeaturingArtist";
+}
 @end

--- a/Classes/Models/Generated/_ArtistDocument.h
+++ b/Classes/Models/Generated/_ArtistDocument.h
@@ -1,25 +1,30 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to ArtistDocument.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "Document.h"
 
-extern const struct ArtistDocumentUserInfo {
-} ArtistDocumentUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 
-@interface ArtistDocumentID : DocumentID {
+@interface ArtistDocumentID : DocumentID
+{
 }
 @end
 
 
-@interface _ArtistDocument : Document {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _ArtistDocument : Document
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (ArtistDocumentID *)objectID;
-
+@property (nonatomic, readonly, strong) ArtistDocumentID *objectID;
 
 @end
 
@@ -27,3 +32,5 @@ extern const struct ArtistDocumentUserInfo {
 @interface _ArtistDocument (CoreDataGeneratedPrimitiveAccessors)
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_ArtistDocument.m
+++ b/Classes/Models/Generated/_ArtistDocument.m
@@ -3,8 +3,6 @@
 
 #import "_ArtistDocument.h"
 
-const struct ArtistDocumentUserInfo ArtistDocumentUserInfo = {};
-
 
 @implementation ArtistDocumentID
 @end
@@ -12,7 +10,7 @@ const struct ArtistDocumentUserInfo ArtistDocumentUserInfo = {};
 
 @implementation _ArtistDocument
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"ArtistDocument" inManagedObjectContext:moc_];
@@ -34,5 +32,11 @@ const struct ArtistDocumentUserInfo ArtistDocumentUserInfo = {};
     return (ArtistDocumentID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    return keyPaths;
+}
 
 @end

--- a/Classes/Models/Generated/_Artwork.h
+++ b/Classes/Models/Generated/_Artwork.h
@@ -1,58 +1,19 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to Artwork.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "ARManagedObject.h"
 
-extern const struct ArtworkAttributes {
-    __unsafe_unretained NSString *availability;
-    __unsafe_unretained NSString *backendPrice;
-    __unsafe_unretained NSString *category;
-    __unsafe_unretained NSString *confidentialNotes;
-    __unsafe_unretained NSString *createdAt;
-    __unsafe_unretained NSString *date;
-    __unsafe_unretained NSString *depth;
-    __unsafe_unretained NSString *diameter;
-    __unsafe_unretained NSString *dimensionsCM;
-    __unsafe_unretained NSString *dimensionsInches;
-    __unsafe_unretained NSString *displayPrice;
-    __unsafe_unretained NSString *displayTitle;
-    __unsafe_unretained NSString *editions;
-    __unsafe_unretained NSString *exhibitionHistory;
-    __unsafe_unretained NSString *height;
-    __unsafe_unretained NSString *imageRights;
-    __unsafe_unretained NSString *info;
-    __unsafe_unretained NSString *inventoryID;
-    __unsafe_unretained NSString *isAvailableForSale;
-    __unsafe_unretained NSString *isPriceHidden;
-    __unsafe_unretained NSString *isPublished;
-    __unsafe_unretained NSString *literature;
-    __unsafe_unretained NSString *medium;
-    __unsafe_unretained NSString *provenance;
-    __unsafe_unretained NSString *series;
-    __unsafe_unretained NSString *signature;
-    __unsafe_unretained NSString *slug;
-    __unsafe_unretained NSString *title;
-    __unsafe_unretained NSString *updatedAt;
-    __unsafe_unretained NSString *width;
-} ArtworkAttributes;
+NS_ASSUME_NONNULL_BEGIN
 
-extern const struct ArtworkRelationships {
-    __unsafe_unretained NSString *artist;
-    __unsafe_unretained NSString *collections;
-    __unsafe_unretained NSString *editionSets;
-    __unsafe_unretained NSString *images;
-    __unsafe_unretained NSString *installShotsFeaturingArtwork;
-    __unsafe_unretained NSString *locations;
-    __unsafe_unretained NSString *mainImage;
-    __unsafe_unretained NSString *notes;
-    __unsafe_unretained NSString *partner;
-    __unsafe_unretained NSString *shows;
-} ArtworkRelationships;
-
-extern const struct ArtworkUserInfo {
-} ArtworkUserInfo;
-
+@class Artist;
 @class Artist;
 @class Album;
 @class EditionSet;
@@ -65,142 +26,306 @@ extern const struct ArtworkUserInfo {
 @class Show;
 
 
-@interface ArtworkID : ARManagedObjectID {
+@interface ArtworkID : NSManagedObjectID
+{
 }
 @end
 
 
-@interface _Artwork : ARManagedObject {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _Artwork : ARManagedObject
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (ArtworkID *)objectID;
+@property (nonatomic, readonly, strong) ArtworkID *objectID;
 
-@property (nonatomic, strong) NSString *availability;
-@property (nonatomic, strong) NSString *backendPrice;
-@property (nonatomic, strong) NSString *category;
-@property (nonatomic, strong) NSString *confidentialNotes;
-@property (nonatomic, strong) NSDate *createdAt;
-@property (nonatomic, strong) NSString *date;
-@property (nonatomic, strong) NSDecimalNumber *depth;
-@property (nonatomic, strong) NSDecimalNumber *diameter;
-@property (nonatomic, strong) NSString *dimensionsCM;
-@property (nonatomic, strong) NSString *dimensionsInches;
-@property (nonatomic, strong) NSString *displayPrice;
-@property (nonatomic, strong) NSString *displayTitle;
-@property (nonatomic, strong) NSString *editions;
-@property (nonatomic, strong) NSString *exhibitionHistory;
-@property (nonatomic, strong) NSDecimalNumber *height;
-@property (nonatomic, strong) NSString *imageRights;
-@property (nonatomic, strong) NSString *info;
-@property (nonatomic, strong) NSString *inventoryID;
-@property (nonatomic, strong) NSNumber *isAvailableForSale;
-@property (nonatomic, strong) NSNumber *isPriceHidden;
-@property (nonatomic, strong) NSNumber *isPublished;
-@property (nonatomic, strong) NSString *literature;
-@property (nonatomic, strong) NSString *medium;
-@property (nonatomic, strong) NSString *provenance;
-@property (nonatomic, strong) NSString *series;
-@property (nonatomic, strong) NSString *signature;
+@property (nonatomic, strong, nullable) NSString *availability;
+
+@property (nonatomic, strong, nullable) NSString *backendPrice;
+
+@property (nonatomic, strong, nullable) NSString *category;
+
+@property (nonatomic, strong, nullable) NSString *confidentialNotes;
+
+@property (nonatomic, strong, nullable) NSDate *createdAt;
+
+@property (nonatomic, strong, nullable) NSString *date;
+
+@property (nonatomic, strong, nullable) NSDecimalNumber *depth;
+
+@property (nonatomic, strong, nullable) NSDecimalNumber *diameter;
+
+@property (nonatomic, strong, nullable) NSString *dimensionsCM;
+
+@property (nonatomic, strong, nullable) NSString *dimensionsInches;
+
+@property (nonatomic, strong, nullable) NSString *displayPrice;
+
+@property (nonatomic, strong, nullable) NSString *displayTitle;
+
+@property (nonatomic, strong, nullable) NSString *editions;
+
+@property (nonatomic, strong, nullable) NSString *exhibitionHistory;
+
+@property (nonatomic, strong, nullable) NSDecimalNumber *height;
+
+@property (nonatomic, strong, nullable) NSString *imageRights;
+
+@property (nonatomic, strong, nullable) NSString *info;
+
+@property (nonatomic, strong, nullable) NSString *inventoryID;
+
+@property (nonatomic, strong, nullable) NSNumber *isAvailableForSale;
+
+@property (atomic) BOOL isAvailableForSaleValue;
+- (BOOL)isAvailableForSaleValue;
+- (void)setIsAvailableForSaleValue:(BOOL)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *isPriceHidden;
+
+@property (atomic) BOOL isPriceHiddenValue;
+- (BOOL)isPriceHiddenValue;
+- (void)setIsPriceHiddenValue:(BOOL)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *isPublished;
+
+@property (atomic) BOOL isPublishedValue;
+- (BOOL)isPublishedValue;
+- (void)setIsPublishedValue:(BOOL)value_;
+
+@property (nonatomic, strong, nullable) NSString *literature;
+
+@property (nonatomic, strong, nullable) NSString *medium;
+
+@property (nonatomic, strong, nullable) NSString *provenance;
+
+@property (nonatomic, strong, nullable) NSString *series;
+
+@property (nonatomic, strong, nullable) NSString *signature;
+
 @property (nonatomic, strong) NSString *slug;
-@property (nonatomic, strong) NSString *title;
-@property (nonatomic, strong) NSDate *updatedAt;
-@property (nonatomic, strong) NSDecimalNumber *width;
-@property (nonatomic, strong) Artist *artist;
 
-@property (nonatomic, strong) NSSet *collections;
-- (NSMutableSet *)collectionsSet;
+@property (nonatomic, strong, nullable) NSString *title;
 
-@property (nonatomic, strong) NSSet *editionSets;
-- (NSMutableSet *)editionSetsSet;
+@property (nonatomic, strong, nullable) NSDate *updatedAt;
 
-@property (nonatomic, strong) NSSet *images;
-- (NSMutableSet *)imagesSet;
+@property (nonatomic, strong, nullable) NSDecimalNumber *width;
 
-@property (nonatomic, strong) NSSet *installShotsFeaturingArtwork;
-- (NSMutableSet *)installShotsFeaturingArtworkSet;
+@property (nonatomic, strong, nullable) Artist *artist;
 
-@property (nonatomic, strong) NSSet *locations;
-- (NSMutableSet *)locationsSet;
-@property (nonatomic, strong) Image *mainImage;
-@property (nonatomic, strong) Note *notes;
-@property (nonatomic, strong) Partner *partner;
+@property (nonatomic, strong, nullable) NSSet<Artist *> *artists;
+- (nullable NSMutableSet<Artist *> *)artistsSet;
 
-@property (nonatomic, strong) NSSet *shows;
-- (NSMutableSet *)showsSet;
+@property (nonatomic, strong, nullable) NSSet<Album *> *collections;
+- (nullable NSMutableSet<Album *> *)collectionsSet;
 
+@property (nonatomic, strong, nullable) NSSet<EditionSet *> *editionSets;
+- (nullable NSMutableSet<EditionSet *> *)editionSetsSet;
+
+@property (nonatomic, strong, nullable) NSSet<Image *> *images;
+- (nullable NSMutableSet<Image *> *)imagesSet;
+
+@property (nonatomic, strong, nullable) NSSet<Image *> *installShotsFeaturingArtwork;
+- (nullable NSMutableSet<Image *> *)installShotsFeaturingArtworkSet;
+
+@property (nonatomic, strong, nullable) NSSet<Location *> *locations;
+- (nullable NSMutableSet<Location *> *)locationsSet;
+
+@property (nonatomic, strong, nullable) Image *mainImage;
+
+@property (nonatomic, strong, nullable) Note *notes;
+
+@property (nonatomic, strong, nullable) Partner *partner;
+
+@property (nonatomic, strong, nullable) NSSet<Show *> *shows;
+- (nullable NSMutableSet<Show *> *)showsSet;
+
+@end
+
+
+@interface _Artwork (ArtistsCoreDataGeneratedAccessors)
+- (void)addArtists:(NSSet<Artist *> *)value_;
+- (void)removeArtists:(NSSet<Artist *> *)value_;
+- (void)addArtistsObject:(Artist *)value_;
+- (void)removeArtistsObject:(Artist *)value_;
 
 @end
 
 
 @interface _Artwork (CollectionsCoreDataGeneratedAccessors)
-- (void)addCollections:(NSSet *)value_;
-- (void)removeCollections:(NSSet *)value_;
+- (void)addCollections:(NSSet<Album *> *)value_;
+- (void)removeCollections:(NSSet<Album *> *)value_;
 - (void)addCollectionsObject:(Album *)value_;
 - (void)removeCollectionsObject:(Album *)value_;
+
 @end
 
 
 @interface _Artwork (EditionSetsCoreDataGeneratedAccessors)
-- (void)addEditionSets:(NSSet *)value_;
-- (void)removeEditionSets:(NSSet *)value_;
+- (void)addEditionSets:(NSSet<EditionSet *> *)value_;
+- (void)removeEditionSets:(NSSet<EditionSet *> *)value_;
 - (void)addEditionSetsObject:(EditionSet *)value_;
 - (void)removeEditionSetsObject:(EditionSet *)value_;
+
 @end
 
 
 @interface _Artwork (ImagesCoreDataGeneratedAccessors)
-- (void)addImages:(NSSet *)value_;
-- (void)removeImages:(NSSet *)value_;
+- (void)addImages:(NSSet<Image *> *)value_;
+- (void)removeImages:(NSSet<Image *> *)value_;
 - (void)addImagesObject:(Image *)value_;
 - (void)removeImagesObject:(Image *)value_;
+
 @end
 
 
 @interface _Artwork (InstallShotsFeaturingArtworkCoreDataGeneratedAccessors)
-- (void)addInstallShotsFeaturingArtwork:(NSSet *)value_;
-- (void)removeInstallShotsFeaturingArtwork:(NSSet *)value_;
+- (void)addInstallShotsFeaturingArtwork:(NSSet<Image *> *)value_;
+- (void)removeInstallShotsFeaturingArtwork:(NSSet<Image *> *)value_;
 - (void)addInstallShotsFeaturingArtworkObject:(Image *)value_;
 - (void)removeInstallShotsFeaturingArtworkObject:(Image *)value_;
+
 @end
 
 
 @interface _Artwork (LocationsCoreDataGeneratedAccessors)
-- (void)addLocations:(NSSet *)value_;
-- (void)removeLocations:(NSSet *)value_;
+- (void)addLocations:(NSSet<Location *> *)value_;
+- (void)removeLocations:(NSSet<Location *> *)value_;
 - (void)addLocationsObject:(Location *)value_;
 - (void)removeLocationsObject:(Location *)value_;
+
 @end
 
 
 @interface _Artwork (ShowsCoreDataGeneratedAccessors)
-- (void)addShows:(NSSet *)value_;
-- (void)removeShows:(NSSet *)value_;
+- (void)addShows:(NSSet<Show *> *)value_;
+- (void)removeShows:(NSSet<Show *> *)value_;
 - (void)addShowsObject:(Show *)value_;
 - (void)removeShowsObject:(Show *)value_;
+
 @end
 
 
 @interface _Artwork (CoreDataGeneratedPrimitiveAccessors)
 
+- (NSString *)primitiveAvailability;
+- (void)setPrimitiveAvailability:(NSString *)value;
+
+- (NSString *)primitiveBackendPrice;
+- (void)setPrimitiveBackendPrice:(NSString *)value;
+
+- (NSString *)primitiveCategory;
+- (void)setPrimitiveCategory:(NSString *)value;
+
+- (NSString *)primitiveConfidentialNotes;
+- (void)setPrimitiveConfidentialNotes:(NSString *)value;
+
+- (NSDate *)primitiveCreatedAt;
+- (void)setPrimitiveCreatedAt:(NSDate *)value;
+
+- (NSString *)primitiveDate;
+- (void)setPrimitiveDate:(NSString *)value;
+
+- (NSDecimalNumber *)primitiveDepth;
+- (void)setPrimitiveDepth:(NSDecimalNumber *)value;
+
+- (NSDecimalNumber *)primitiveDiameter;
+- (void)setPrimitiveDiameter:(NSDecimalNumber *)value;
+
+- (NSString *)primitiveDimensionsCM;
+- (void)setPrimitiveDimensionsCM:(NSString *)value;
+
+- (NSString *)primitiveDimensionsInches;
+- (void)setPrimitiveDimensionsInches:(NSString *)value;
+
+- (NSString *)primitiveDisplayPrice;
+- (void)setPrimitiveDisplayPrice:(NSString *)value;
+
+- (NSString *)primitiveDisplayTitle;
+- (void)setPrimitiveDisplayTitle:(NSString *)value;
+
+- (NSString *)primitiveEditions;
+- (void)setPrimitiveEditions:(NSString *)value;
+
+- (NSString *)primitiveExhibitionHistory;
+- (void)setPrimitiveExhibitionHistory:(NSString *)value;
+
+- (NSDecimalNumber *)primitiveHeight;
+- (void)setPrimitiveHeight:(NSDecimalNumber *)value;
+
+- (NSString *)primitiveImageRights;
+- (void)setPrimitiveImageRights:(NSString *)value;
+
+- (NSString *)primitiveInfo;
+- (void)setPrimitiveInfo:(NSString *)value;
+
+- (NSString *)primitiveInventoryID;
+- (void)setPrimitiveInventoryID:(NSString *)value;
+
+- (NSNumber *)primitiveIsAvailableForSale;
+- (void)setPrimitiveIsAvailableForSale:(NSNumber *)value;
+
+- (BOOL)primitiveIsAvailableForSaleValue;
+- (void)setPrimitiveIsAvailableForSaleValue:(BOOL)value_;
+
+- (NSNumber *)primitiveIsPriceHidden;
+- (void)setPrimitiveIsPriceHidden:(NSNumber *)value;
+
+- (BOOL)primitiveIsPriceHiddenValue;
+- (void)setPrimitiveIsPriceHiddenValue:(BOOL)value_;
+
+- (NSNumber *)primitiveIsPublished;
+- (void)setPrimitiveIsPublished:(NSNumber *)value;
+
+- (BOOL)primitiveIsPublishedValue;
+- (void)setPrimitiveIsPublishedValue:(BOOL)value_;
+
+- (NSString *)primitiveLiterature;
+- (void)setPrimitiveLiterature:(NSString *)value;
+
+- (NSString *)primitiveMedium;
+- (void)setPrimitiveMedium:(NSString *)value;
+
+- (NSString *)primitiveProvenance;
+- (void)setPrimitiveProvenance:(NSString *)value;
+
+- (NSString *)primitiveSeries;
+- (void)setPrimitiveSeries:(NSString *)value;
+
+- (NSString *)primitiveSignature;
+- (void)setPrimitiveSignature:(NSString *)value;
+
+- (NSString *)primitiveSlug;
+- (void)setPrimitiveSlug:(NSString *)value;
+
+- (NSString *)primitiveTitle;
+- (void)setPrimitiveTitle:(NSString *)value;
+
+- (NSDate *)primitiveUpdatedAt;
+- (void)setPrimitiveUpdatedAt:(NSDate *)value;
+
+- (NSDecimalNumber *)primitiveWidth;
+- (void)setPrimitiveWidth:(NSDecimalNumber *)value;
+
 - (Artist *)primitiveArtist;
 - (void)setPrimitiveArtist:(Artist *)value;
 
-- (NSMutableSet *)primitiveCollections;
-- (void)setPrimitiveCollections:(NSMutableSet *)value;
+- (NSMutableSet<Artist *> *)primitiveArtists;
+- (void)setPrimitiveArtists:(NSMutableSet<Artist *> *)value;
 
-- (NSMutableSet *)primitiveEditionSets;
-- (void)setPrimitiveEditionSets:(NSMutableSet *)value;
+- (NSMutableSet<Album *> *)primitiveCollections;
+- (void)setPrimitiveCollections:(NSMutableSet<Album *> *)value;
 
-- (NSMutableSet *)primitiveImages;
-- (void)setPrimitiveImages:(NSMutableSet *)value;
+- (NSMutableSet<EditionSet *> *)primitiveEditionSets;
+- (void)setPrimitiveEditionSets:(NSMutableSet<EditionSet *> *)value;
 
-- (NSMutableSet *)primitiveInstallShotsFeaturingArtwork;
-- (void)setPrimitiveInstallShotsFeaturingArtwork:(NSMutableSet *)value;
+- (NSMutableSet<Image *> *)primitiveImages;
+- (void)setPrimitiveImages:(NSMutableSet<Image *> *)value;
 
-- (NSMutableSet *)primitiveLocations;
-- (void)setPrimitiveLocations:(NSMutableSet *)value;
+- (NSMutableSet<Image *> *)primitiveInstallShotsFeaturingArtwork;
+- (void)setPrimitiveInstallShotsFeaturingArtwork:(NSMutableSet<Image *> *)value;
+
+- (NSMutableSet<Location *> *)primitiveLocations;
+- (void)setPrimitiveLocations:(NSMutableSet<Location *> *)value;
 
 - (Image *)primitiveMainImage;
 - (void)setPrimitiveMainImage:(Image *)value;
@@ -211,7 +336,58 @@ extern const struct ArtworkUserInfo {
 - (Partner *)primitivePartner;
 - (void)setPrimitivePartner:(Partner *)value;
 
-- (NSMutableSet *)primitiveShows;
-- (void)setPrimitiveShows:(NSMutableSet *)value;
+- (NSMutableSet<Show *> *)primitiveShows;
+- (void)setPrimitiveShows:(NSMutableSet<Show *> *)value;
 
 @end
+
+
+@interface ArtworkAttributes : NSObject
++ (NSString *)availability;
++ (NSString *)backendPrice;
++ (NSString *)category;
++ (NSString *)confidentialNotes;
++ (NSString *)createdAt;
++ (NSString *)date;
++ (NSString *)depth;
++ (NSString *)diameter;
++ (NSString *)dimensionsCM;
++ (NSString *)dimensionsInches;
++ (NSString *)displayPrice;
++ (NSString *)displayTitle;
++ (NSString *)editions;
++ (NSString *)exhibitionHistory;
++ (NSString *)height;
++ (NSString *)imageRights;
++ (NSString *)info;
++ (NSString *)inventoryID;
++ (NSString *)isAvailableForSale;
++ (NSString *)isPriceHidden;
++ (NSString *)isPublished;
++ (NSString *)literature;
++ (NSString *)medium;
++ (NSString *)provenance;
++ (NSString *)series;
++ (NSString *)signature;
++ (NSString *)slug;
++ (NSString *)title;
++ (NSString *)updatedAt;
++ (NSString *)width;
+@end
+
+
+@interface ArtworkRelationships : NSObject
++ (NSString *)artist;
++ (NSString *)artists;
++ (NSString *)collections;
++ (NSString *)editionSets;
++ (NSString *)images;
++ (NSString *)installShotsFeaturingArtwork;
++ (NSString *)locations;
++ (NSString *)mainImage;
++ (NSString *)notes;
++ (NSString *)partner;
++ (NSString *)shows;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_Artwork.m
+++ b/Classes/Models/Generated/_Artwork.m
@@ -3,54 +3,6 @@
 
 #import "_Artwork.h"
 
-const struct ArtworkAttributes ArtworkAttributes = {
-    .availability = @"availability",
-    .backendPrice = @"backendPrice",
-    .category = @"category",
-    .confidentialNotes = @"confidentialNotes",
-    .createdAt = @"createdAt",
-    .date = @"date",
-    .depth = @"depth",
-    .diameter = @"diameter",
-    .dimensionsCM = @"dimensionsCM",
-    .dimensionsInches = @"dimensionsInches",
-    .displayPrice = @"displayPrice",
-    .displayTitle = @"displayTitle",
-    .editions = @"editions",
-    .exhibitionHistory = @"exhibitionHistory",
-    .height = @"height",
-    .imageRights = @"imageRights",
-    .info = @"info",
-    .inventoryID = @"inventoryID",
-    .isAvailableForSale = @"isAvailableForSale",
-    .isPriceHidden = @"isPriceHidden",
-    .isPublished = @"isPublished",
-    .literature = @"literature",
-    .medium = @"medium",
-    .provenance = @"provenance",
-    .series = @"series",
-    .signature = @"signature",
-    .slug = @"slug",
-    .title = @"title",
-    .updatedAt = @"updatedAt",
-    .width = @"width",
-};
-
-const struct ArtworkRelationships ArtworkRelationships = {
-    .artist = @"artist",
-    .collections = @"collections",
-    .editionSets = @"editionSets",
-    .images = @"images",
-    .installShotsFeaturingArtwork = @"installShotsFeaturingArtwork",
-    .locations = @"locations",
-    .mainImage = @"mainImage",
-    .notes = @"notes",
-    .partner = @"partner",
-    .shows = @"shows",
-};
-
-const struct ArtworkUserInfo ArtworkUserInfo = {};
-
 
 @implementation ArtworkID
 @end
@@ -58,7 +10,7 @@ const struct ArtworkUserInfo ArtworkUserInfo = {};
 
 @implementation _Artwork
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"Artwork" inManagedObjectContext:moc_];
@@ -80,96 +32,417 @@ const struct ArtworkUserInfo ArtworkUserInfo = {};
     return (ArtworkID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    if ([key isEqualToString:@"isAvailableForSaleValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"isAvailableForSale"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"isPriceHiddenValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"isPriceHidden"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"isPublishedValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"isPublished"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+
+    return keyPaths;
+}
 
 @dynamic availability;
+
 @dynamic backendPrice;
+
 @dynamic category;
+
 @dynamic confidentialNotes;
+
 @dynamic createdAt;
+
 @dynamic date;
+
 @dynamic depth;
+
 @dynamic diameter;
+
 @dynamic dimensionsCM;
+
 @dynamic dimensionsInches;
+
 @dynamic displayPrice;
+
 @dynamic displayTitle;
+
 @dynamic editions;
+
 @dynamic exhibitionHistory;
+
 @dynamic height;
+
 @dynamic imageRights;
+
 @dynamic info;
+
 @dynamic inventoryID;
+
 @dynamic isAvailableForSale;
+
+- (BOOL)isAvailableForSaleValue
+{
+    NSNumber *result = [self isAvailableForSale];
+    return [result boolValue];
+}
+
+- (void)setIsAvailableForSaleValue:(BOOL)value_
+{
+    [self setIsAvailableForSale:@(value_)];
+}
+
+- (BOOL)primitiveIsAvailableForSaleValue
+{
+    NSNumber *result = [self primitiveIsAvailableForSale];
+    return [result boolValue];
+}
+
+- (void)setPrimitiveIsAvailableForSaleValue:(BOOL)value_
+{
+    [self setPrimitiveIsAvailableForSale:@(value_)];
+}
+
 @dynamic isPriceHidden;
+
+- (BOOL)isPriceHiddenValue
+{
+    NSNumber *result = [self isPriceHidden];
+    return [result boolValue];
+}
+
+- (void)setIsPriceHiddenValue:(BOOL)value_
+{
+    [self setIsPriceHidden:@(value_)];
+}
+
+- (BOOL)primitiveIsPriceHiddenValue
+{
+    NSNumber *result = [self primitiveIsPriceHidden];
+    return [result boolValue];
+}
+
+- (void)setPrimitiveIsPriceHiddenValue:(BOOL)value_
+{
+    [self setPrimitiveIsPriceHidden:@(value_)];
+}
+
 @dynamic isPublished;
+
+- (BOOL)isPublishedValue
+{
+    NSNumber *result = [self isPublished];
+    return [result boolValue];
+}
+
+- (void)setIsPublishedValue:(BOOL)value_
+{
+    [self setIsPublished:@(value_)];
+}
+
+- (BOOL)primitiveIsPublishedValue
+{
+    NSNumber *result = [self primitiveIsPublished];
+    return [result boolValue];
+}
+
+- (void)setPrimitiveIsPublishedValue:(BOOL)value_
+{
+    [self setPrimitiveIsPublished:@(value_)];
+}
+
 @dynamic literature;
+
 @dynamic medium;
+
 @dynamic provenance;
+
 @dynamic series;
+
 @dynamic signature;
+
 @dynamic slug;
+
 @dynamic title;
+
 @dynamic updatedAt;
+
 @dynamic width;
 
-
 @dynamic artist;
+
+@dynamic artists;
+
+- (NSMutableSet<Artist *> *)artistsSet
+{
+    [self willAccessValueForKey:@"artists"];
+
+    NSMutableSet<Artist *> *result = (NSMutableSet<Artist *> *)[self mutableSetValueForKey:@"artists"];
+
+    [self didAccessValueForKey:@"artists"];
+    return result;
+}
+
 @dynamic collections;
-- (NSMutableSet *)collectionsSet
+
+- (NSMutableSet<Album *> *)collectionsSet
 {
     [self willAccessValueForKey:@"collections"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"collections"];
+
+    NSMutableSet<Album *> *result = (NSMutableSet<Album *> *)[self mutableSetValueForKey:@"collections"];
+
     [self didAccessValueForKey:@"collections"];
     return result;
 }
 
 @dynamic editionSets;
-- (NSMutableSet *)editionSetsSet
+
+- (NSMutableSet<EditionSet *> *)editionSetsSet
 {
     [self willAccessValueForKey:@"editionSets"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"editionSets"];
+
+    NSMutableSet<EditionSet *> *result = (NSMutableSet<EditionSet *> *)[self mutableSetValueForKey:@"editionSets"];
+
     [self didAccessValueForKey:@"editionSets"];
     return result;
 }
 
 @dynamic images;
-- (NSMutableSet *)imagesSet
+
+- (NSMutableSet<Image *> *)imagesSet
 {
     [self willAccessValueForKey:@"images"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"images"];
+
+    NSMutableSet<Image *> *result = (NSMutableSet<Image *> *)[self mutableSetValueForKey:@"images"];
+
     [self didAccessValueForKey:@"images"];
     return result;
 }
 
 @dynamic installShotsFeaturingArtwork;
-- (NSMutableSet *)installShotsFeaturingArtworkSet
+
+- (NSMutableSet<Image *> *)installShotsFeaturingArtworkSet
 {
     [self willAccessValueForKey:@"installShotsFeaturingArtwork"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"installShotsFeaturingArtwork"];
+
+    NSMutableSet<Image *> *result = (NSMutableSet<Image *> *)[self mutableSetValueForKey:@"installShotsFeaturingArtwork"];
+
     [self didAccessValueForKey:@"installShotsFeaturingArtwork"];
     return result;
 }
 
 @dynamic locations;
-- (NSMutableSet *)locationsSet
+
+- (NSMutableSet<Location *> *)locationsSet
 {
     [self willAccessValueForKey:@"locations"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"locations"];
+
+    NSMutableSet<Location *> *result = (NSMutableSet<Location *> *)[self mutableSetValueForKey:@"locations"];
+
     [self didAccessValueForKey:@"locations"];
     return result;
 }
 
 @dynamic mainImage;
+
 @dynamic notes;
+
 @dynamic partner;
+
 @dynamic shows;
-- (NSMutableSet *)showsSet
+
+- (NSMutableSet<Show *> *)showsSet
 {
     [self willAccessValueForKey:@"shows"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"shows"];
+
+    NSMutableSet<Show *> *result = (NSMutableSet<Show *> *)[self mutableSetValueForKey:@"shows"];
+
     [self didAccessValueForKey:@"shows"];
     return result;
 }
 
+@end
 
+
+@implementation ArtworkAttributes
++ (NSString *)availability
+{
+    return @"availability";
+}
++ (NSString *)backendPrice
+{
+    return @"backendPrice";
+}
++ (NSString *)category
+{
+    return @"category";
+}
++ (NSString *)confidentialNotes
+{
+    return @"confidentialNotes";
+}
++ (NSString *)createdAt
+{
+    return @"createdAt";
+}
++ (NSString *)date
+{
+    return @"date";
+}
++ (NSString *)depth
+{
+    return @"depth";
+}
++ (NSString *)diameter
+{
+    return @"diameter";
+}
++ (NSString *)dimensionsCM
+{
+    return @"dimensionsCM";
+}
++ (NSString *)dimensionsInches
+{
+    return @"dimensionsInches";
+}
++ (NSString *)displayPrice
+{
+    return @"displayPrice";
+}
++ (NSString *)displayTitle
+{
+    return @"displayTitle";
+}
++ (NSString *)editions
+{
+    return @"editions";
+}
++ (NSString *)exhibitionHistory
+{
+    return @"exhibitionHistory";
+}
++ (NSString *)height
+{
+    return @"height";
+}
++ (NSString *)imageRights
+{
+    return @"imageRights";
+}
++ (NSString *)info
+{
+    return @"info";
+}
++ (NSString *)inventoryID
+{
+    return @"inventoryID";
+}
++ (NSString *)isAvailableForSale
+{
+    return @"isAvailableForSale";
+}
++ (NSString *)isPriceHidden
+{
+    return @"isPriceHidden";
+}
++ (NSString *)isPublished
+{
+    return @"isPublished";
+}
++ (NSString *)literature
+{
+    return @"literature";
+}
++ (NSString *)medium
+{
+    return @"medium";
+}
++ (NSString *)provenance
+{
+    return @"provenance";
+}
++ (NSString *)series
+{
+    return @"series";
+}
++ (NSString *)signature
+{
+    return @"signature";
+}
++ (NSString *)slug
+{
+    return @"slug";
+}
++ (NSString *)title
+{
+    return @"title";
+}
++ (NSString *)updatedAt
+{
+    return @"updatedAt";
+}
++ (NSString *)width
+{
+    return @"width";
+}
+@end
+
+
+@implementation ArtworkRelationships
++ (NSString *)artist
+{
+    return @"artist";
+}
++ (NSString *)artists
+{
+    return @"artists";
+}
++ (NSString *)collections
+{
+    return @"collections";
+}
++ (NSString *)editionSets
+{
+    return @"editionSets";
+}
++ (NSString *)images
+{
+    return @"images";
+}
++ (NSString *)installShotsFeaturingArtwork
+{
+    return @"installShotsFeaturingArtwork";
+}
++ (NSString *)locations
+{
+    return @"locations";
+}
++ (NSString *)mainImage
+{
+    return @"mainImage";
+}
++ (NSString *)notes
+{
+    return @"notes";
+}
++ (NSString *)partner
+{
+    return @"partner";
+}
++ (NSString *)shows
+{
+    return @"shows";
+}
 @end

--- a/Classes/Models/Generated/_Document.h
+++ b/Classes/Models/Generated/_Document.h
@@ -1,63 +1,106 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to Document.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "ARManagedObject.h"
 
-extern const struct DocumentAttributes {
-    __unsafe_unretained NSString *filename;
-    __unsafe_unretained NSString *hasFile;
-    __unsafe_unretained NSString *humanReadableSize;
-    __unsafe_unretained NSString *size;
-    __unsafe_unretained NSString *slug;
-    __unsafe_unretained NSString *title;
-    __unsafe_unretained NSString *url;
-    __unsafe_unretained NSString *version;
-} DocumentAttributes;
-
-extern const struct DocumentRelationships {
-    __unsafe_unretained NSString *album;
-    __unsafe_unretained NSString *artist;
-    __unsafe_unretained NSString *show;
-} DocumentRelationships;
-
-extern const struct DocumentUserInfo {
-} DocumentUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 @class Album;
 @class Artist;
 @class Show;
 
 
-@interface DocumentID : ARManagedObjectID {
+@interface DocumentID : NSManagedObjectID
+{
 }
 @end
 
 
-@interface _Document : ARManagedObject {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _Document : ARManagedObject
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (DocumentID *)objectID;
+@property (nonatomic, readonly, strong) DocumentID *objectID;
 
-@property (nonatomic, strong) NSString *filename;
-@property (nonatomic, strong) NSNumber *hasFile;
-@property (nonatomic, strong) NSString *humanReadableSize;
-@property (nonatomic, strong) NSNumber *size;
+@property (nonatomic, strong, nullable) NSString *filename;
+
+@property (nonatomic, strong, nullable) NSNumber *hasFile;
+
+@property (atomic) BOOL hasFileValue;
+- (BOOL)hasFileValue;
+- (void)setHasFileValue:(BOOL)value_;
+
+@property (nonatomic, strong, nullable) NSString *humanReadableSize;
+
+@property (nonatomic, strong, nullable) NSNumber *size;
+
+@property (atomic) int32_t sizeValue;
+- (int32_t)sizeValue;
+- (void)setSizeValue:(int32_t)value_;
+
 @property (nonatomic, strong) NSString *slug;
-@property (nonatomic, strong) NSString *title;
-@property (nonatomic, strong) NSString *url;
-@property (nonatomic, strong) NSNumber *version;
-@property (nonatomic, strong) Album *album;
-@property (nonatomic, strong) Artist *artist;
-@property (nonatomic, strong) Show *show;
 
+@property (nonatomic, strong, nullable) NSString *title;
+
+@property (nonatomic, strong, nullable) NSString *url;
+
+@property (nonatomic, strong, nullable) NSNumber *version;
+
+@property (atomic) int16_t versionValue;
+- (int16_t)versionValue;
+- (void)setVersionValue:(int16_t)value_;
+
+@property (nonatomic, strong, nullable) Album *album;
+
+@property (nonatomic, strong, nullable) Artist *artist;
+
+@property (nonatomic, strong, nullable) Show *show;
 
 @end
 
 
 @interface _Document (CoreDataGeneratedPrimitiveAccessors)
+
+- (NSString *)primitiveFilename;
+- (void)setPrimitiveFilename:(NSString *)value;
+
+- (NSNumber *)primitiveHasFile;
+- (void)setPrimitiveHasFile:(NSNumber *)value;
+
+- (BOOL)primitiveHasFileValue;
+- (void)setPrimitiveHasFileValue:(BOOL)value_;
+
+- (NSString *)primitiveHumanReadableSize;
+- (void)setPrimitiveHumanReadableSize:(NSString *)value;
+
+- (NSNumber *)primitiveSize;
+- (void)setPrimitiveSize:(NSNumber *)value;
+
+- (int32_t)primitiveSizeValue;
+- (void)setPrimitiveSizeValue:(int32_t)value_;
+
+- (NSString *)primitiveSlug;
+- (void)setPrimitiveSlug:(NSString *)value;
+
+- (NSString *)primitiveTitle;
+- (void)setPrimitiveTitle:(NSString *)value;
+
+- (NSString *)primitiveUrl;
+- (void)setPrimitiveUrl:(NSString *)value;
+
+- (NSNumber *)primitiveVersion;
+- (void)setPrimitiveVersion:(NSNumber *)value;
+
+- (int16_t)primitiveVersionValue;
+- (void)setPrimitiveVersionValue:(int16_t)value_;
 
 - (Album *)primitiveAlbum;
 - (void)setPrimitiveAlbum:(Album *)value;
@@ -69,3 +112,24 @@ extern const struct DocumentUserInfo {
 - (void)setPrimitiveShow:(Show *)value;
 
 @end
+
+
+@interface DocumentAttributes : NSObject
++ (NSString *)filename;
++ (NSString *)hasFile;
++ (NSString *)humanReadableSize;
++ (NSString *)size;
++ (NSString *)slug;
++ (NSString *)title;
++ (NSString *)url;
++ (NSString *)version;
+@end
+
+
+@interface DocumentRelationships : NSObject
++ (NSString *)album;
++ (NSString *)artist;
++ (NSString *)show;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_Document.m
+++ b/Classes/Models/Generated/_Document.m
@@ -3,25 +3,6 @@
 
 #import "_Document.h"
 
-const struct DocumentAttributes DocumentAttributes = {
-    .filename = @"filename",
-    .hasFile = @"hasFile",
-    .humanReadableSize = @"humanReadableSize",
-    .size = @"size",
-    .slug = @"slug",
-    .title = @"title",
-    .url = @"url",
-    .version = @"version",
-};
-
-const struct DocumentRelationships DocumentRelationships = {
-    .album = @"album",
-    .artist = @"artist",
-    .show = @"show",
-};
-
-const struct DocumentUserInfo DocumentUserInfo = {};
-
 
 @implementation DocumentID
 @end
@@ -29,7 +10,7 @@ const struct DocumentUserInfo DocumentUserInfo = {};
 
 @implementation _Document
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"Document" inManagedObjectContext:moc_];
@@ -51,20 +32,167 @@ const struct DocumentUserInfo DocumentUserInfo = {};
     return (DocumentID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    if ([key isEqualToString:@"hasFileValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"hasFile"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"sizeValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"size"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"versionValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"version"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+
+    return keyPaths;
+}
 
 @dynamic filename;
+
 @dynamic hasFile;
+
+- (BOOL)hasFileValue
+{
+    NSNumber *result = [self hasFile];
+    return [result boolValue];
+}
+
+- (void)setHasFileValue:(BOOL)value_
+{
+    [self setHasFile:@(value_)];
+}
+
+- (BOOL)primitiveHasFileValue
+{
+    NSNumber *result = [self primitiveHasFile];
+    return [result boolValue];
+}
+
+- (void)setPrimitiveHasFileValue:(BOOL)value_
+{
+    [self setPrimitiveHasFile:@(value_)];
+}
+
 @dynamic humanReadableSize;
+
 @dynamic size;
+
+- (int32_t)sizeValue
+{
+    NSNumber *result = [self size];
+    return [result intValue];
+}
+
+- (void)setSizeValue:(int32_t)value_
+{
+    [self setSize:@(value_)];
+}
+
+- (int32_t)primitiveSizeValue
+{
+    NSNumber *result = [self primitiveSize];
+    return [result intValue];
+}
+
+- (void)setPrimitiveSizeValue:(int32_t)value_
+{
+    [self setPrimitiveSize:@(value_)];
+}
+
 @dynamic slug;
+
 @dynamic title;
+
 @dynamic url;
+
 @dynamic version;
 
+- (int16_t)versionValue
+{
+    NSNumber *result = [self version];
+    return [result shortValue];
+}
+
+- (void)setVersionValue:(int16_t)value_
+{
+    [self setVersion:@(value_)];
+}
+
+- (int16_t)primitiveVersionValue
+{
+    NSNumber *result = [self primitiveVersion];
+    return [result shortValue];
+}
+
+- (void)setPrimitiveVersionValue:(int16_t)value_
+{
+    [self setPrimitiveVersion:@(value_)];
+}
 
 @dynamic album;
+
 @dynamic artist;
+
 @dynamic show;
 
+@end
 
+
+@implementation DocumentAttributes
++ (NSString *)filename
+{
+    return @"filename";
+}
++ (NSString *)hasFile
+{
+    return @"hasFile";
+}
++ (NSString *)humanReadableSize
+{
+    return @"humanReadableSize";
+}
++ (NSString *)size
+{
+    return @"size";
+}
++ (NSString *)slug
+{
+    return @"slug";
+}
++ (NSString *)title
+{
+    return @"title";
+}
++ (NSString *)url
+{
+    return @"url";
+}
++ (NSString *)version
+{
+    return @"version";
+}
+@end
+
+
+@implementation DocumentRelationships
++ (NSString *)album
+{
+    return @"album";
+}
++ (NSString *)artist
+{
+    return @"artist";
+}
++ (NSString *)show
+{
+    return @"show";
+}
 @end

--- a/Classes/Models/Generated/_EditionSet.h
+++ b/Classes/Models/Generated/_EditionSet.h
@@ -1,79 +1,174 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to EditionSet.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "ARManagedObject.h"
 
-extern const struct EditionSetAttributes {
-    __unsafe_unretained NSString *artistProofs;
-    __unsafe_unretained NSString *availability;
-    __unsafe_unretained NSString *availableEditions;
-    __unsafe_unretained NSString *backendPrice;
-    __unsafe_unretained NSString *depth;
-    __unsafe_unretained NSString *diameter;
-    __unsafe_unretained NSString *dimensionsCM;
-    __unsafe_unretained NSString *dimensionsInches;
-    __unsafe_unretained NSString *displayPrice;
-    __unsafe_unretained NSString *duration;
-    __unsafe_unretained NSString *editionSize;
-    __unsafe_unretained NSString *editions;
-    __unsafe_unretained NSString *height;
-    __unsafe_unretained NSString *isAvailableForSale;
-    __unsafe_unretained NSString *isPriceHidden;
-    __unsafe_unretained NSString *prototypes;
-    __unsafe_unretained NSString *slug;
-    __unsafe_unretained NSString *width;
-} EditionSetAttributes;
-
-extern const struct EditionSetRelationships {
-    __unsafe_unretained NSString *artwork;
-} EditionSetRelationships;
-
-extern const struct EditionSetUserInfo {
-} EditionSetUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 @class Artwork;
 
 
-@interface EditionSetID : ARManagedObjectID {
+@interface EditionSetID : NSManagedObjectID
+{
 }
 @end
 
 
-@interface _EditionSet : ARManagedObject {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _EditionSet : ARManagedObject
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (EditionSetID *)objectID;
+@property (nonatomic, readonly, strong) EditionSetID *objectID;
 
-@property (nonatomic, strong) NSString *artistProofs;
-@property (nonatomic, strong) NSString *availability;
-@property (nonatomic, strong) NSString *availableEditions;
-@property (nonatomic, strong) NSString *backendPrice;
-@property (nonatomic, strong) NSDecimalNumber *depth;
-@property (nonatomic, strong) NSDecimalNumber *diameter;
-@property (nonatomic, strong) NSString *dimensionsCM;
-@property (nonatomic, strong) NSString *dimensionsInches;
-@property (nonatomic, strong) NSString *displayPrice;
-@property (nonatomic, strong) NSString *duration;
-@property (nonatomic, strong) NSString *editionSize;
-@property (nonatomic, strong) NSString *editions;
-@property (nonatomic, strong) NSDecimalNumber *height;
-@property (nonatomic, strong) NSNumber *isAvailableForSale;
-@property (nonatomic, strong) NSNumber *isPriceHidden;
-@property (nonatomic, strong) NSString *prototypes;
-@property (nonatomic, strong) NSString *slug;
-@property (nonatomic, strong) NSDecimalNumber *width;
-@property (nonatomic, strong) Artwork *artwork;
+@property (nonatomic, strong, nullable) NSString *artistProofs;
 
+@property (nonatomic, strong, nullable) NSString *availability;
+
+@property (nonatomic, strong, nullable) NSString *availableEditions;
+
+@property (nonatomic, strong, nullable) NSString *backendPrice;
+
+@property (nonatomic, strong, nullable) NSDecimalNumber *depth;
+
+@property (nonatomic, strong, nullable) NSDecimalNumber *diameter;
+
+@property (nonatomic, strong, nullable) NSString *dimensionsCM;
+
+@property (nonatomic, strong, nullable) NSString *dimensionsInches;
+
+@property (nonatomic, strong, nullable) NSString *displayPrice;
+
+@property (nonatomic, strong, nullable) NSString *duration;
+
+@property (nonatomic, strong, nullable) NSString *editionSize;
+
+@property (nonatomic, strong, nullable) NSString *editions;
+
+@property (nonatomic, strong, nullable) NSDecimalNumber *height;
+
+@property (nonatomic, strong, nullable) NSNumber *isAvailableForSale;
+
+@property (atomic) BOOL isAvailableForSaleValue;
+- (BOOL)isAvailableForSaleValue;
+- (void)setIsAvailableForSaleValue:(BOOL)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *isPriceHidden;
+
+@property (atomic) BOOL isPriceHiddenValue;
+- (BOOL)isPriceHiddenValue;
+- (void)setIsPriceHiddenValue:(BOOL)value_;
+
+@property (nonatomic, strong, nullable) NSString *prototypes;
+
+@property (nonatomic, strong, nullable) NSString *slug;
+
+@property (nonatomic, strong, nullable) NSDecimalNumber *width;
+
+@property (nonatomic, strong, nullable) Artwork *artwork;
 
 @end
 
 
 @interface _EditionSet (CoreDataGeneratedPrimitiveAccessors)
 
+- (NSString *)primitiveArtistProofs;
+- (void)setPrimitiveArtistProofs:(NSString *)value;
+
+- (NSString *)primitiveAvailability;
+- (void)setPrimitiveAvailability:(NSString *)value;
+
+- (NSString *)primitiveAvailableEditions;
+- (void)setPrimitiveAvailableEditions:(NSString *)value;
+
+- (NSString *)primitiveBackendPrice;
+- (void)setPrimitiveBackendPrice:(NSString *)value;
+
+- (NSDecimalNumber *)primitiveDepth;
+- (void)setPrimitiveDepth:(NSDecimalNumber *)value;
+
+- (NSDecimalNumber *)primitiveDiameter;
+- (void)setPrimitiveDiameter:(NSDecimalNumber *)value;
+
+- (NSString *)primitiveDimensionsCM;
+- (void)setPrimitiveDimensionsCM:(NSString *)value;
+
+- (NSString *)primitiveDimensionsInches;
+- (void)setPrimitiveDimensionsInches:(NSString *)value;
+
+- (NSString *)primitiveDisplayPrice;
+- (void)setPrimitiveDisplayPrice:(NSString *)value;
+
+- (NSString *)primitiveDuration;
+- (void)setPrimitiveDuration:(NSString *)value;
+
+- (NSString *)primitiveEditionSize;
+- (void)setPrimitiveEditionSize:(NSString *)value;
+
+- (NSString *)primitiveEditions;
+- (void)setPrimitiveEditions:(NSString *)value;
+
+- (NSDecimalNumber *)primitiveHeight;
+- (void)setPrimitiveHeight:(NSDecimalNumber *)value;
+
+- (NSNumber *)primitiveIsAvailableForSale;
+- (void)setPrimitiveIsAvailableForSale:(NSNumber *)value;
+
+- (BOOL)primitiveIsAvailableForSaleValue;
+- (void)setPrimitiveIsAvailableForSaleValue:(BOOL)value_;
+
+- (NSNumber *)primitiveIsPriceHidden;
+- (void)setPrimitiveIsPriceHidden:(NSNumber *)value;
+
+- (BOOL)primitiveIsPriceHiddenValue;
+- (void)setPrimitiveIsPriceHiddenValue:(BOOL)value_;
+
+- (NSString *)primitivePrototypes;
+- (void)setPrimitivePrototypes:(NSString *)value;
+
+- (NSString *)primitiveSlug;
+- (void)setPrimitiveSlug:(NSString *)value;
+
+- (NSDecimalNumber *)primitiveWidth;
+- (void)setPrimitiveWidth:(NSDecimalNumber *)value;
+
 - (Artwork *)primitiveArtwork;
 - (void)setPrimitiveArtwork:(Artwork *)value;
 
 @end
+
+
+@interface EditionSetAttributes : NSObject
++ (NSString *)artistProofs;
++ (NSString *)availability;
++ (NSString *)availableEditions;
++ (NSString *)backendPrice;
++ (NSString *)depth;
++ (NSString *)diameter;
++ (NSString *)dimensionsCM;
++ (NSString *)dimensionsInches;
++ (NSString *)displayPrice;
++ (NSString *)duration;
++ (NSString *)editionSize;
++ (NSString *)editions;
++ (NSString *)height;
++ (NSString *)isAvailableForSale;
++ (NSString *)isPriceHidden;
++ (NSString *)prototypes;
++ (NSString *)slug;
++ (NSString *)width;
+@end
+
+
+@interface EditionSetRelationships : NSObject
++ (NSString *)artwork;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_EditionSet.m
+++ b/Classes/Models/Generated/_EditionSet.m
@@ -3,33 +3,6 @@
 
 #import "_EditionSet.h"
 
-const struct EditionSetAttributes EditionSetAttributes = {
-    .artistProofs = @"artistProofs",
-    .availability = @"availability",
-    .availableEditions = @"availableEditions",
-    .backendPrice = @"backendPrice",
-    .depth = @"depth",
-    .diameter = @"diameter",
-    .dimensionsCM = @"dimensionsCM",
-    .dimensionsInches = @"dimensionsInches",
-    .displayPrice = @"displayPrice",
-    .duration = @"duration",
-    .editionSize = @"editionSize",
-    .editions = @"editions",
-    .height = @"height",
-    .isAvailableForSale = @"isAvailableForSale",
-    .isPriceHidden = @"isPriceHidden",
-    .prototypes = @"prototypes",
-    .slug = @"slug",
-    .width = @"width",
-};
-
-const struct EditionSetRelationships EditionSetRelationships = {
-    .artwork = @"artwork",
-};
-
-const struct EditionSetUserInfo EditionSetUserInfo = {};
-
 
 @implementation EditionSetID
 @end
@@ -37,7 +10,7 @@ const struct EditionSetUserInfo EditionSetUserInfo = {};
 
 @implementation _EditionSet
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"EditionSet" inManagedObjectContext:moc_];
@@ -59,28 +32,188 @@ const struct EditionSetUserInfo EditionSetUserInfo = {};
     return (EditionSetID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    if ([key isEqualToString:@"isAvailableForSaleValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"isAvailableForSale"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"isPriceHiddenValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"isPriceHidden"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+
+    return keyPaths;
+}
 
 @dynamic artistProofs;
-@dynamic availability;
-@dynamic availableEditions;
-@dynamic backendPrice;
-@dynamic depth;
-@dynamic diameter;
-@dynamic dimensionsCM;
-@dynamic dimensionsInches;
-@dynamic displayPrice;
-@dynamic duration;
-@dynamic editionSize;
-@dynamic editions;
-@dynamic height;
-@dynamic isAvailableForSale;
-@dynamic isPriceHidden;
-@dynamic prototypes;
-@dynamic slug;
-@dynamic width;
 
+@dynamic availability;
+
+@dynamic availableEditions;
+
+@dynamic backendPrice;
+
+@dynamic depth;
+
+@dynamic diameter;
+
+@dynamic dimensionsCM;
+
+@dynamic dimensionsInches;
+
+@dynamic displayPrice;
+
+@dynamic duration;
+
+@dynamic editionSize;
+
+@dynamic editions;
+
+@dynamic height;
+
+@dynamic isAvailableForSale;
+
+- (BOOL)isAvailableForSaleValue
+{
+    NSNumber *result = [self isAvailableForSale];
+    return [result boolValue];
+}
+
+- (void)setIsAvailableForSaleValue:(BOOL)value_
+{
+    [self setIsAvailableForSale:@(value_)];
+}
+
+- (BOOL)primitiveIsAvailableForSaleValue
+{
+    NSNumber *result = [self primitiveIsAvailableForSale];
+    return [result boolValue];
+}
+
+- (void)setPrimitiveIsAvailableForSaleValue:(BOOL)value_
+{
+    [self setPrimitiveIsAvailableForSale:@(value_)];
+}
+
+@dynamic isPriceHidden;
+
+- (BOOL)isPriceHiddenValue
+{
+    NSNumber *result = [self isPriceHidden];
+    return [result boolValue];
+}
+
+- (void)setIsPriceHiddenValue:(BOOL)value_
+{
+    [self setIsPriceHidden:@(value_)];
+}
+
+- (BOOL)primitiveIsPriceHiddenValue
+{
+    NSNumber *result = [self primitiveIsPriceHidden];
+    return [result boolValue];
+}
+
+- (void)setPrimitiveIsPriceHiddenValue:(BOOL)value_
+{
+    [self setPrimitiveIsPriceHidden:@(value_)];
+}
+
+@dynamic prototypes;
+
+@dynamic slug;
+
+@dynamic width;
 
 @dynamic artwork;
 
+@end
 
+
+@implementation EditionSetAttributes
++ (NSString *)artistProofs
+{
+    return @"artistProofs";
+}
++ (NSString *)availability
+{
+    return @"availability";
+}
++ (NSString *)availableEditions
+{
+    return @"availableEditions";
+}
++ (NSString *)backendPrice
+{
+    return @"backendPrice";
+}
++ (NSString *)depth
+{
+    return @"depth";
+}
++ (NSString *)diameter
+{
+    return @"diameter";
+}
++ (NSString *)dimensionsCM
+{
+    return @"dimensionsCM";
+}
++ (NSString *)dimensionsInches
+{
+    return @"dimensionsInches";
+}
++ (NSString *)displayPrice
+{
+    return @"displayPrice";
+}
++ (NSString *)duration
+{
+    return @"duration";
+}
++ (NSString *)editionSize
+{
+    return @"editionSize";
+}
++ (NSString *)editions
+{
+    return @"editions";
+}
++ (NSString *)height
+{
+    return @"height";
+}
++ (NSString *)isAvailableForSale
+{
+    return @"isAvailableForSale";
+}
++ (NSString *)isPriceHidden
+{
+    return @"isPriceHidden";
+}
++ (NSString *)prototypes
+{
+    return @"prototypes";
+}
++ (NSString *)slug
+{
+    return @"slug";
+}
++ (NSString *)width
+{
+    return @"width";
+}
+@end
+
+
+@implementation EditionSetRelationships
++ (NSString *)artwork
+{
+    return @"artwork";
+}
 @end

--- a/Classes/Models/Generated/_Image.h
+++ b/Classes/Models/Generated/_Image.h
@@ -1,38 +1,17 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to Image.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "ARManagedObject.h"
 
-extern const struct ImageAttributes {
-    __unsafe_unretained NSString *aspectRatio;
-    __unsafe_unretained NSString *baseURL;
-    __unsafe_unretained NSString *isMainImage;
-    __unsafe_unretained NSString *maxTiledHeight;
-    __unsafe_unretained NSString *maxTiledWidth;
-    __unsafe_unretained NSString *originalHeight;
-    __unsafe_unretained NSString *originalWidth;
-    __unsafe_unretained NSString *position;
-    __unsafe_unretained NSString *processing;
-    __unsafe_unretained NSString *slug;
-    __unsafe_unretained NSString *tileBaseUrl;
-    __unsafe_unretained NSString *tileFormat;
-    __unsafe_unretained NSString *tileOverlap;
-    __unsafe_unretained NSString *tileSize;
-} ImageAttributes;
-
-extern const struct ImageRelationships {
-    __unsafe_unretained NSString *artistsInImage;
-    __unsafe_unretained NSString *artwork;
-    __unsafe_unretained NSString *artworksInImage;
-    __unsafe_unretained NSString *coverForAlbum;
-    __unsafe_unretained NSString *coverForArtist;
-    __unsafe_unretained NSString *coverForShow;
-    __unsafe_unretained NSString *mainImageForArtwork;
-} ImageRelationships;
-
-extern const struct ImageUserInfo {
-} ImageUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 @class Artist;
 @class Artwork;
@@ -43,45 +22,176 @@ extern const struct ImageUserInfo {
 @class Artwork;
 
 
-@interface ImageID : ARManagedObjectID {
+@interface ImageID : NSManagedObjectID
+{
 }
 @end
 
 
-@interface _Image : ARManagedObject {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _Image : ARManagedObject
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (ImageID *)objectID;
+@property (nonatomic, readonly, strong) ImageID *objectID;
 
-@property (nonatomic, strong) NSNumber *aspectRatio;
-@property (nonatomic, strong) NSString *baseURL;
-@property (nonatomic, strong) NSNumber *isMainImage;
-@property (nonatomic, strong) NSNumber *maxTiledHeight;
-@property (nonatomic, strong) NSNumber *maxTiledWidth;
-@property (nonatomic, strong) NSNumber *originalHeight;
-@property (nonatomic, strong) NSNumber *originalWidth;
-@property (nonatomic, strong) NSNumber *position;
-@property (nonatomic, strong) NSNumber *processing;
+@property (nonatomic, strong, nullable) NSNumber *aspectRatio;
+
+@property (atomic) float aspectRatioValue;
+- (float)aspectRatioValue;
+- (void)setAspectRatioValue:(float)value_;
+
+@property (nonatomic, strong, nullable) NSString *baseURL;
+
+@property (nonatomic, strong, nullable) NSNumber *isMainImage;
+
+@property (atomic) BOOL isMainImageValue;
+- (BOOL)isMainImageValue;
+- (void)setIsMainImageValue:(BOOL)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *maxTiledHeight;
+
+@property (atomic) int16_t maxTiledHeightValue;
+- (int16_t)maxTiledHeightValue;
+- (void)setMaxTiledHeightValue:(int16_t)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *maxTiledWidth;
+
+@property (atomic) int16_t maxTiledWidthValue;
+- (int16_t)maxTiledWidthValue;
+- (void)setMaxTiledWidthValue:(int16_t)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *originalHeight;
+
+@property (atomic) float originalHeightValue;
+- (float)originalHeightValue;
+- (void)setOriginalHeightValue:(float)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *originalWidth;
+
+@property (atomic) float originalWidthValue;
+- (float)originalWidthValue;
+- (void)setOriginalWidthValue:(float)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *position;
+
+@property (atomic) int16_t positionValue;
+- (int16_t)positionValue;
+- (void)setPositionValue:(int16_t)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *processing;
+
+@property (atomic) BOOL processingValue;
+- (BOOL)processingValue;
+- (void)setProcessingValue:(BOOL)value_;
+
 @property (nonatomic, strong) NSString *slug;
-@property (nonatomic, strong) NSString *tileBaseUrl;
-@property (nonatomic, strong) NSString *tileFormat;
-@property (nonatomic, strong) NSNumber *tileOverlap;
-@property (nonatomic, strong) NSNumber *tileSize;
-@property (nonatomic, strong) Artist *artistsInImage;
-@property (nonatomic, strong) Artwork *artwork;
-@property (nonatomic, strong) Artwork *artworksInImage;
-@property (nonatomic, strong) Album *coverForAlbum;
-@property (nonatomic, strong) Artist *coverForArtist;
-@property (nonatomic, strong) Show *coverForShow;
-@property (nonatomic, strong) Artwork *mainImageForArtwork;
 
+@property (nonatomic, strong, nullable) NSString *tileBaseUrl;
+
+@property (nonatomic, strong, nullable) NSString *tileFormat;
+
+@property (nonatomic, strong, nullable) NSNumber *tileOverlap;
+
+@property (atomic) int16_t tileOverlapValue;
+- (int16_t)tileOverlapValue;
+- (void)setTileOverlapValue:(int16_t)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *tileSize;
+
+@property (atomic) int16_t tileSizeValue;
+- (int16_t)tileSizeValue;
+- (void)setTileSizeValue:(int16_t)value_;
+
+@property (nonatomic, strong, nullable) Artist *artistsInImage;
+
+@property (nonatomic, strong, nullable) Artwork *artwork;
+
+@property (nonatomic, strong, nullable) Artwork *artworksInImage;
+
+@property (nonatomic, strong, nullable) Album *coverForAlbum;
+
+@property (nonatomic, strong, nullable) Artist *coverForArtist;
+
+@property (nonatomic, strong, nullable) Show *coverForShow;
+
+@property (nonatomic, strong, nullable) Artwork *mainImageForArtwork;
 
 @end
 
 
 @interface _Image (CoreDataGeneratedPrimitiveAccessors)
+
+- (NSNumber *)primitiveAspectRatio;
+- (void)setPrimitiveAspectRatio:(NSNumber *)value;
+
+- (float)primitiveAspectRatioValue;
+- (void)setPrimitiveAspectRatioValue:(float)value_;
+
+- (NSString *)primitiveBaseURL;
+- (void)setPrimitiveBaseURL:(NSString *)value;
+
+- (NSNumber *)primitiveIsMainImage;
+- (void)setPrimitiveIsMainImage:(NSNumber *)value;
+
+- (BOOL)primitiveIsMainImageValue;
+- (void)setPrimitiveIsMainImageValue:(BOOL)value_;
+
+- (NSNumber *)primitiveMaxTiledHeight;
+- (void)setPrimitiveMaxTiledHeight:(NSNumber *)value;
+
+- (int16_t)primitiveMaxTiledHeightValue;
+- (void)setPrimitiveMaxTiledHeightValue:(int16_t)value_;
+
+- (NSNumber *)primitiveMaxTiledWidth;
+- (void)setPrimitiveMaxTiledWidth:(NSNumber *)value;
+
+- (int16_t)primitiveMaxTiledWidthValue;
+- (void)setPrimitiveMaxTiledWidthValue:(int16_t)value_;
+
+- (NSNumber *)primitiveOriginalHeight;
+- (void)setPrimitiveOriginalHeight:(NSNumber *)value;
+
+- (float)primitiveOriginalHeightValue;
+- (void)setPrimitiveOriginalHeightValue:(float)value_;
+
+- (NSNumber *)primitiveOriginalWidth;
+- (void)setPrimitiveOriginalWidth:(NSNumber *)value;
+
+- (float)primitiveOriginalWidthValue;
+- (void)setPrimitiveOriginalWidthValue:(float)value_;
+
+- (NSNumber *)primitivePosition;
+- (void)setPrimitivePosition:(NSNumber *)value;
+
+- (int16_t)primitivePositionValue;
+- (void)setPrimitivePositionValue:(int16_t)value_;
+
+- (NSNumber *)primitiveProcessing;
+- (void)setPrimitiveProcessing:(NSNumber *)value;
+
+- (BOOL)primitiveProcessingValue;
+- (void)setPrimitiveProcessingValue:(BOOL)value_;
+
+- (NSString *)primitiveSlug;
+- (void)setPrimitiveSlug:(NSString *)value;
+
+- (NSString *)primitiveTileBaseUrl;
+- (void)setPrimitiveTileBaseUrl:(NSString *)value;
+
+- (NSString *)primitiveTileFormat;
+- (void)setPrimitiveTileFormat:(NSString *)value;
+
+- (NSNumber *)primitiveTileOverlap;
+- (void)setPrimitiveTileOverlap:(NSNumber *)value;
+
+- (int16_t)primitiveTileOverlapValue;
+- (void)setPrimitiveTileOverlapValue:(int16_t)value_;
+
+- (NSNumber *)primitiveTileSize;
+- (void)setPrimitiveTileSize:(NSNumber *)value;
+
+- (int16_t)primitiveTileSizeValue;
+- (void)setPrimitiveTileSizeValue:(int16_t)value_;
 
 - (Artist *)primitiveArtistsInImage;
 - (void)setPrimitiveArtistsInImage:(Artist *)value;
@@ -105,3 +215,34 @@ extern const struct ImageUserInfo {
 - (void)setPrimitiveMainImageForArtwork:(Artwork *)value;
 
 @end
+
+
+@interface ImageAttributes : NSObject
++ (NSString *)aspectRatio;
++ (NSString *)baseURL;
++ (NSString *)isMainImage;
++ (NSString *)maxTiledHeight;
++ (NSString *)maxTiledWidth;
++ (NSString *)originalHeight;
++ (NSString *)originalWidth;
++ (NSString *)position;
++ (NSString *)processing;
++ (NSString *)slug;
++ (NSString *)tileBaseUrl;
++ (NSString *)tileFormat;
++ (NSString *)tileOverlap;
++ (NSString *)tileSize;
+@end
+
+
+@interface ImageRelationships : NSObject
++ (NSString *)artistsInImage;
++ (NSString *)artwork;
++ (NSString *)artworksInImage;
++ (NSString *)coverForAlbum;
++ (NSString *)coverForArtist;
++ (NSString *)coverForShow;
++ (NSString *)mainImageForArtwork;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_Image.m
+++ b/Classes/Models/Generated/_Image.m
@@ -3,35 +3,6 @@
 
 #import "_Image.h"
 
-const struct ImageAttributes ImageAttributes = {
-    .aspectRatio = @"aspectRatio",
-    .baseURL = @"baseURL",
-    .isMainImage = @"isMainImage",
-    .maxTiledHeight = @"maxTiledHeight",
-    .maxTiledWidth = @"maxTiledWidth",
-    .originalHeight = @"originalHeight",
-    .originalWidth = @"originalWidth",
-    .position = @"position",
-    .processing = @"processing",
-    .slug = @"slug",
-    .tileBaseUrl = @"tileBaseUrl",
-    .tileFormat = @"tileFormat",
-    .tileOverlap = @"tileOverlap",
-    .tileSize = @"tileSize",
-};
-
-const struct ImageRelationships ImageRelationships = {
-    .artistsInImage = @"artistsInImage",
-    .artwork = @"artwork",
-    .artworksInImage = @"artworksInImage",
-    .coverForAlbum = @"coverForAlbum",
-    .coverForArtist = @"coverForArtist",
-    .coverForShow = @"coverForShow",
-    .mainImageForArtwork = @"mainImageForArtwork",
-};
-
-const struct ImageUserInfo ImageUserInfo = {};
-
 
 @implementation ImageID
 @end
@@ -39,7 +10,7 @@ const struct ImageUserInfo ImageUserInfo = {};
 
 @implementation _Image
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"Image" inManagedObjectContext:moc_];
@@ -61,30 +32,416 @@ const struct ImageUserInfo ImageUserInfo = {};
     return (ImageID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    if ([key isEqualToString:@"aspectRatioValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"aspectRatio"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"isMainImageValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"isMainImage"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"maxTiledHeightValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"maxTiledHeight"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"maxTiledWidthValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"maxTiledWidth"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"originalHeightValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"originalHeight"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"originalWidthValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"originalWidth"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"positionValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"position"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"processingValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"processing"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"tileOverlapValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"tileOverlap"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"tileSizeValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"tileSize"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+
+    return keyPaths;
+}
 
 @dynamic aspectRatio;
+
+- (float)aspectRatioValue
+{
+    NSNumber *result = [self aspectRatio];
+    return [result floatValue];
+}
+
+- (void)setAspectRatioValue:(float)value_
+{
+    [self setAspectRatio:@(value_)];
+}
+
+- (float)primitiveAspectRatioValue
+{
+    NSNumber *result = [self primitiveAspectRatio];
+    return [result floatValue];
+}
+
+- (void)setPrimitiveAspectRatioValue:(float)value_
+{
+    [self setPrimitiveAspectRatio:@(value_)];
+}
+
 @dynamic baseURL;
+
 @dynamic isMainImage;
+
+- (BOOL)isMainImageValue
+{
+    NSNumber *result = [self isMainImage];
+    return [result boolValue];
+}
+
+- (void)setIsMainImageValue:(BOOL)value_
+{
+    [self setIsMainImage:@(value_)];
+}
+
+- (BOOL)primitiveIsMainImageValue
+{
+    NSNumber *result = [self primitiveIsMainImage];
+    return [result boolValue];
+}
+
+- (void)setPrimitiveIsMainImageValue:(BOOL)value_
+{
+    [self setPrimitiveIsMainImage:@(value_)];
+}
+
 @dynamic maxTiledHeight;
+
+- (int16_t)maxTiledHeightValue
+{
+    NSNumber *result = [self maxTiledHeight];
+    return [result shortValue];
+}
+
+- (void)setMaxTiledHeightValue:(int16_t)value_
+{
+    [self setMaxTiledHeight:@(value_)];
+}
+
+- (int16_t)primitiveMaxTiledHeightValue
+{
+    NSNumber *result = [self primitiveMaxTiledHeight];
+    return [result shortValue];
+}
+
+- (void)setPrimitiveMaxTiledHeightValue:(int16_t)value_
+{
+    [self setPrimitiveMaxTiledHeight:@(value_)];
+}
+
 @dynamic maxTiledWidth;
+
+- (int16_t)maxTiledWidthValue
+{
+    NSNumber *result = [self maxTiledWidth];
+    return [result shortValue];
+}
+
+- (void)setMaxTiledWidthValue:(int16_t)value_
+{
+    [self setMaxTiledWidth:@(value_)];
+}
+
+- (int16_t)primitiveMaxTiledWidthValue
+{
+    NSNumber *result = [self primitiveMaxTiledWidth];
+    return [result shortValue];
+}
+
+- (void)setPrimitiveMaxTiledWidthValue:(int16_t)value_
+{
+    [self setPrimitiveMaxTiledWidth:@(value_)];
+}
+
 @dynamic originalHeight;
+
+- (float)originalHeightValue
+{
+    NSNumber *result = [self originalHeight];
+    return [result floatValue];
+}
+
+- (void)setOriginalHeightValue:(float)value_
+{
+    [self setOriginalHeight:@(value_)];
+}
+
+- (float)primitiveOriginalHeightValue
+{
+    NSNumber *result = [self primitiveOriginalHeight];
+    return [result floatValue];
+}
+
+- (void)setPrimitiveOriginalHeightValue:(float)value_
+{
+    [self setPrimitiveOriginalHeight:@(value_)];
+}
+
 @dynamic originalWidth;
+
+- (float)originalWidthValue
+{
+    NSNumber *result = [self originalWidth];
+    return [result floatValue];
+}
+
+- (void)setOriginalWidthValue:(float)value_
+{
+    [self setOriginalWidth:@(value_)];
+}
+
+- (float)primitiveOriginalWidthValue
+{
+    NSNumber *result = [self primitiveOriginalWidth];
+    return [result floatValue];
+}
+
+- (void)setPrimitiveOriginalWidthValue:(float)value_
+{
+    [self setPrimitiveOriginalWidth:@(value_)];
+}
+
 @dynamic position;
+
+- (int16_t)positionValue
+{
+    NSNumber *result = [self position];
+    return [result shortValue];
+}
+
+- (void)setPositionValue:(int16_t)value_
+{
+    [self setPosition:@(value_)];
+}
+
+- (int16_t)primitivePositionValue
+{
+    NSNumber *result = [self primitivePosition];
+    return [result shortValue];
+}
+
+- (void)setPrimitivePositionValue:(int16_t)value_
+{
+    [self setPrimitivePosition:@(value_)];
+}
+
 @dynamic processing;
+
+- (BOOL)processingValue
+{
+    NSNumber *result = [self processing];
+    return [result boolValue];
+}
+
+- (void)setProcessingValue:(BOOL)value_
+{
+    [self setProcessing:@(value_)];
+}
+
+- (BOOL)primitiveProcessingValue
+{
+    NSNumber *result = [self primitiveProcessing];
+    return [result boolValue];
+}
+
+- (void)setPrimitiveProcessingValue:(BOOL)value_
+{
+    [self setPrimitiveProcessing:@(value_)];
+}
+
 @dynamic slug;
+
 @dynamic tileBaseUrl;
+
 @dynamic tileFormat;
+
 @dynamic tileOverlap;
+
+- (int16_t)tileOverlapValue
+{
+    NSNumber *result = [self tileOverlap];
+    return [result shortValue];
+}
+
+- (void)setTileOverlapValue:(int16_t)value_
+{
+    [self setTileOverlap:@(value_)];
+}
+
+- (int16_t)primitiveTileOverlapValue
+{
+    NSNumber *result = [self primitiveTileOverlap];
+    return [result shortValue];
+}
+
+- (void)setPrimitiveTileOverlapValue:(int16_t)value_
+{
+    [self setPrimitiveTileOverlap:@(value_)];
+}
+
 @dynamic tileSize;
 
+- (int16_t)tileSizeValue
+{
+    NSNumber *result = [self tileSize];
+    return [result shortValue];
+}
+
+- (void)setTileSizeValue:(int16_t)value_
+{
+    [self setTileSize:@(value_)];
+}
+
+- (int16_t)primitiveTileSizeValue
+{
+    NSNumber *result = [self primitiveTileSize];
+    return [result shortValue];
+}
+
+- (void)setPrimitiveTileSizeValue:(int16_t)value_
+{
+    [self setPrimitiveTileSize:@(value_)];
+}
 
 @dynamic artistsInImage;
+
 @dynamic artwork;
+
 @dynamic artworksInImage;
+
 @dynamic coverForAlbum;
+
 @dynamic coverForArtist;
+
 @dynamic coverForShow;
+
 @dynamic mainImageForArtwork;
 
+@end
 
+
+@implementation ImageAttributes
++ (NSString *)aspectRatio
+{
+    return @"aspectRatio";
+}
++ (NSString *)baseURL
+{
+    return @"baseURL";
+}
++ (NSString *)isMainImage
+{
+    return @"isMainImage";
+}
++ (NSString *)maxTiledHeight
+{
+    return @"maxTiledHeight";
+}
++ (NSString *)maxTiledWidth
+{
+    return @"maxTiledWidth";
+}
++ (NSString *)originalHeight
+{
+    return @"originalHeight";
+}
++ (NSString *)originalWidth
+{
+    return @"originalWidth";
+}
++ (NSString *)position
+{
+    return @"position";
+}
++ (NSString *)processing
+{
+    return @"processing";
+}
++ (NSString *)slug
+{
+    return @"slug";
+}
++ (NSString *)tileBaseUrl
+{
+    return @"tileBaseUrl";
+}
++ (NSString *)tileFormat
+{
+    return @"tileFormat";
+}
++ (NSString *)tileOverlap
+{
+    return @"tileOverlap";
+}
++ (NSString *)tileSize
+{
+    return @"tileSize";
+}
+@end
+
+
+@implementation ImageRelationships
++ (NSString *)artistsInImage
+{
+    return @"artistsInImage";
+}
++ (NSString *)artwork
+{
+    return @"artwork";
+}
++ (NSString *)artworksInImage
+{
+    return @"artworksInImage";
+}
++ (NSString *)coverForAlbum
+{
+    return @"coverForAlbum";
+}
++ (NSString *)coverForArtist
+{
+    return @"coverForArtist";
+}
++ (NSString *)coverForShow
+{
+    return @"coverForShow";
+}
++ (NSString *)mainImageForArtwork
+{
+    return @"mainImageForArtwork";
+}
 @end

--- a/Classes/Models/Generated/_InstallShotImage.h
+++ b/Classes/Models/Generated/_InstallShotImage.h
@@ -1,45 +1,58 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to InstallShotImage.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "Image.h"
 
-extern const struct InstallShotImageAttributes {
-    __unsafe_unretained NSString *caption;
-} InstallShotImageAttributes;
-
-extern const struct InstallShotImageRelationships {
-    __unsafe_unretained NSString *showWithImageInInstallation;
-} InstallShotImageRelationships;
-
-extern const struct InstallShotImageUserInfo {
-} InstallShotImageUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 @class Show;
 
 
-@interface InstallShotImageID : ImageID {
+@interface InstallShotImageID : ImageID
+{
 }
 @end
 
 
-@interface _InstallShotImage : Image {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _InstallShotImage : Image
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (InstallShotImageID *)objectID;
+@property (nonatomic, readonly, strong) InstallShotImageID *objectID;
 
-@property (nonatomic, strong) NSString *caption;
-@property (nonatomic, strong) Show *showWithImageInInstallation;
+@property (nonatomic, strong, nullable) NSString *caption;
 
+@property (nonatomic, strong, nullable) Show *showWithImageInInstallation;
 
 @end
 
 
 @interface _InstallShotImage (CoreDataGeneratedPrimitiveAccessors)
 
+- (NSString *)primitiveCaption;
+- (void)setPrimitiveCaption:(NSString *)value;
+
 - (Show *)primitiveShowWithImageInInstallation;
 - (void)setPrimitiveShowWithImageInInstallation:(Show *)value;
 
 @end
+
+
+@interface InstallShotImageAttributes : NSObject
++ (NSString *)caption;
+@end
+
+
+@interface InstallShotImageRelationships : NSObject
++ (NSString *)showWithImageInInstallation;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_InstallShotImage.m
+++ b/Classes/Models/Generated/_InstallShotImage.m
@@ -3,16 +3,6 @@
 
 #import "_InstallShotImage.h"
 
-const struct InstallShotImageAttributes InstallShotImageAttributes = {
-    .caption = @"caption",
-};
-
-const struct InstallShotImageRelationships InstallShotImageRelationships = {
-    .showWithImageInInstallation = @"showWithImageInInstallation",
-};
-
-const struct InstallShotImageUserInfo InstallShotImageUserInfo = {};
-
 
 @implementation InstallShotImageID
 @end
@@ -20,7 +10,7 @@ const struct InstallShotImageUserInfo InstallShotImageUserInfo = {};
 
 @implementation _InstallShotImage
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"InstallShotImage" inManagedObjectContext:moc_];
@@ -42,11 +32,31 @@ const struct InstallShotImageUserInfo InstallShotImageUserInfo = {};
     return (InstallShotImageID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    return keyPaths;
+}
 
 @dynamic caption;
 
-
 @dynamic showWithImageInInstallation;
 
+@end
 
+
+@implementation InstallShotImageAttributes
++ (NSString *)caption
+{
+    return @"caption";
+}
+@end
+
+
+@implementation InstallShotImageRelationships
++ (NSString *)showWithImageInInstallation
+{
+    return @"showWithImageInInstallation";
+}
 @end

--- a/Classes/Models/Generated/_LocalImage.h
+++ b/Classes/Models/Generated/_LocalImage.h
@@ -1,25 +1,30 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to LocalImage.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "Image.h"
 
-extern const struct LocalImageUserInfo {
-} LocalImageUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 
-@interface LocalImageID : ImageID {
+@interface LocalImageID : ImageID
+{
 }
 @end
 
 
-@interface _LocalImage : Image {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _LocalImage : Image
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (LocalImageID *)objectID;
-
+@property (nonatomic, readonly, strong) LocalImageID *objectID;
 
 @end
 
@@ -27,3 +32,5 @@ extern const struct LocalImageUserInfo {
 @interface _LocalImage (CoreDataGeneratedPrimitiveAccessors)
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_LocalImage.m
+++ b/Classes/Models/Generated/_LocalImage.m
@@ -3,8 +3,6 @@
 
 #import "_LocalImage.h"
 
-const struct LocalImageUserInfo LocalImageUserInfo = {};
-
 
 @implementation LocalImageID
 @end
@@ -12,7 +10,7 @@ const struct LocalImageUserInfo LocalImageUserInfo = {};
 
 @implementation _LocalImage
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"LocalImage" inManagedObjectContext:moc_];
@@ -34,5 +32,11 @@ const struct LocalImageUserInfo LocalImageUserInfo = {};
     return (LocalImageID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    return keyPaths;
+}
 
 @end

--- a/Classes/Models/Generated/_Location.h
+++ b/Classes/Models/Generated/_Location.h
@@ -1,87 +1,133 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to Location.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "ARManagedObject.h"
 
-extern const struct LocationAttributes {
-    __unsafe_unretained NSString *address;
-    __unsafe_unretained NSString *addressSecond;
-    __unsafe_unretained NSString *city;
-    __unsafe_unretained NSString *geoPoint;
-    __unsafe_unretained NSString *name;
-    __unsafe_unretained NSString *phone;
-    __unsafe_unretained NSString *postalCode;
-    __unsafe_unretained NSString *slug;
-    __unsafe_unretained NSString *state;
-} LocationAttributes;
-
-extern const struct LocationRelationships {
-    __unsafe_unretained NSString *artworks;
-    __unsafe_unretained NSString *shows;
-} LocationRelationships;
-
-extern const struct LocationUserInfo {
-} LocationUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 @class Artwork;
 @class Show;
 
 
-@interface LocationID : ARManagedObjectID {
+@interface LocationID : NSManagedObjectID
+{
 }
 @end
 
 
-@interface _Location : ARManagedObject {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _Location : ARManagedObject
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (LocationID *)objectID;
+@property (nonatomic, readonly, strong) LocationID *objectID;
 
-@property (nonatomic, strong) NSString *address;
-@property (nonatomic, strong) NSString *addressSecond;
-@property (nonatomic, strong) NSString *city;
-@property (nonatomic, strong) NSString *geoPoint;
-@property (nonatomic, strong) NSString *name;
-@property (nonatomic, strong) NSString *phone;
-@property (nonatomic, strong) NSString *postalCode;
+@property (nonatomic, strong, nullable) NSString *address;
+
+@property (nonatomic, strong, nullable) NSString *addressSecond;
+
+@property (nonatomic, strong, nullable) NSString *city;
+
+@property (nonatomic, strong, nullable) NSString *geoPoint;
+
+@property (nonatomic, strong, nullable) NSString *name;
+
+@property (nonatomic, strong, nullable) NSString *phone;
+
+@property (nonatomic, strong, nullable) NSString *postalCode;
+
 @property (nonatomic, strong) NSString *slug;
-@property (nonatomic, strong) NSString *state;
 
-@property (nonatomic, strong) NSSet *artworks;
-- (NSMutableSet *)artworksSet;
+@property (nonatomic, strong, nullable) NSString *state;
 
-@property (nonatomic, strong) NSSet *shows;
-- (NSMutableSet *)showsSet;
+@property (nonatomic, strong, nullable) NSSet<Artwork *> *artworks;
+- (nullable NSMutableSet<Artwork *> *)artworksSet;
 
+@property (nonatomic, strong, nullable) NSSet<Show *> *shows;
+- (nullable NSMutableSet<Show *> *)showsSet;
 
 @end
 
 
 @interface _Location (ArtworksCoreDataGeneratedAccessors)
-- (void)addArtworks:(NSSet *)value_;
-- (void)removeArtworks:(NSSet *)value_;
+- (void)addArtworks:(NSSet<Artwork *> *)value_;
+- (void)removeArtworks:(NSSet<Artwork *> *)value_;
 - (void)addArtworksObject:(Artwork *)value_;
 - (void)removeArtworksObject:(Artwork *)value_;
+
 @end
 
 
 @interface _Location (ShowsCoreDataGeneratedAccessors)
-- (void)addShows:(NSSet *)value_;
-- (void)removeShows:(NSSet *)value_;
+- (void)addShows:(NSSet<Show *> *)value_;
+- (void)removeShows:(NSSet<Show *> *)value_;
 - (void)addShowsObject:(Show *)value_;
 - (void)removeShowsObject:(Show *)value_;
+
 @end
 
 
 @interface _Location (CoreDataGeneratedPrimitiveAccessors)
 
-- (NSMutableSet *)primitiveArtworks;
-- (void)setPrimitiveArtworks:(NSMutableSet *)value;
+- (NSString *)primitiveAddress;
+- (void)setPrimitiveAddress:(NSString *)value;
 
-- (NSMutableSet *)primitiveShows;
-- (void)setPrimitiveShows:(NSMutableSet *)value;
+- (NSString *)primitiveAddressSecond;
+- (void)setPrimitiveAddressSecond:(NSString *)value;
+
+- (NSString *)primitiveCity;
+- (void)setPrimitiveCity:(NSString *)value;
+
+- (NSString *)primitiveGeoPoint;
+- (void)setPrimitiveGeoPoint:(NSString *)value;
+
+- (NSString *)primitiveName;
+- (void)setPrimitiveName:(NSString *)value;
+
+- (NSString *)primitivePhone;
+- (void)setPrimitivePhone:(NSString *)value;
+
+- (NSString *)primitivePostalCode;
+- (void)setPrimitivePostalCode:(NSString *)value;
+
+- (NSString *)primitiveSlug;
+- (void)setPrimitiveSlug:(NSString *)value;
+
+- (NSString *)primitiveState;
+- (void)setPrimitiveState:(NSString *)value;
+
+- (NSMutableSet<Artwork *> *)primitiveArtworks;
+- (void)setPrimitiveArtworks:(NSMutableSet<Artwork *> *)value;
+
+- (NSMutableSet<Show *> *)primitiveShows;
+- (void)setPrimitiveShows:(NSMutableSet<Show *> *)value;
 
 @end
+
+
+@interface LocationAttributes : NSObject
++ (NSString *)address;
++ (NSString *)addressSecond;
++ (NSString *)city;
++ (NSString *)geoPoint;
++ (NSString *)name;
++ (NSString *)phone;
++ (NSString *)postalCode;
++ (NSString *)slug;
++ (NSString *)state;
+@end
+
+
+@interface LocationRelationships : NSObject
++ (NSString *)artworks;
++ (NSString *)shows;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_Location.m
+++ b/Classes/Models/Generated/_Location.m
@@ -3,25 +3,6 @@
 
 #import "_Location.h"
 
-const struct LocationAttributes LocationAttributes = {
-    .address = @"address",
-    .addressSecond = @"addressSecond",
-    .city = @"city",
-    .geoPoint = @"geoPoint",
-    .name = @"name",
-    .phone = @"phone",
-    .postalCode = @"postalCode",
-    .slug = @"slug",
-    .state = @"state",
-};
-
-const struct LocationRelationships LocationRelationships = {
-    .artworks = @"artworks",
-    .shows = @"shows",
-};
-
-const struct LocationUserInfo LocationUserInfo = {};
-
 
 @implementation LocationID
 @end
@@ -29,7 +10,7 @@ const struct LocationUserInfo LocationUserInfo = {};
 
 @implementation _Location
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"Location" inManagedObjectContext:moc_];
@@ -51,35 +32,105 @@ const struct LocationUserInfo LocationUserInfo = {};
     return (LocationID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    return keyPaths;
+}
 
 @dynamic address;
+
 @dynamic addressSecond;
+
 @dynamic city;
+
 @dynamic geoPoint;
+
 @dynamic name;
+
 @dynamic phone;
+
 @dynamic postalCode;
+
 @dynamic slug;
+
 @dynamic state;
 
-
 @dynamic artworks;
-- (NSMutableSet *)artworksSet
+
+- (NSMutableSet<Artwork *> *)artworksSet
 {
     [self willAccessValueForKey:@"artworks"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"artworks"];
+
+    NSMutableSet<Artwork *> *result = (NSMutableSet<Artwork *> *)[self mutableSetValueForKey:@"artworks"];
+
     [self didAccessValueForKey:@"artworks"];
     return result;
 }
 
 @dynamic shows;
-- (NSMutableSet *)showsSet
+
+- (NSMutableSet<Show *> *)showsSet
 {
     [self willAccessValueForKey:@"shows"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"shows"];
+
+    NSMutableSet<Show *> *result = (NSMutableSet<Show *> *)[self mutableSetValueForKey:@"shows"];
+
     [self didAccessValueForKey:@"shows"];
     return result;
 }
 
+@end
 
+
+@implementation LocationAttributes
++ (NSString *)address
+{
+    return @"address";
+}
++ (NSString *)addressSecond
+{
+    return @"addressSecond";
+}
++ (NSString *)city
+{
+    return @"city";
+}
++ (NSString *)geoPoint
+{
+    return @"geoPoint";
+}
++ (NSString *)name
+{
+    return @"name";
+}
++ (NSString *)phone
+{
+    return @"phone";
+}
++ (NSString *)postalCode
+{
+    return @"postalCode";
+}
++ (NSString *)slug
+{
+    return @"slug";
+}
++ (NSString *)state
+{
+    return @"state";
+}
+@end
+
+
+@implementation LocationRelationships
++ (NSString *)artworks
+{
+    return @"artworks";
+}
++ (NSString *)shows
+{
+    return @"shows";
+}
 @end

--- a/Classes/Models/Generated/_Note.h
+++ b/Classes/Models/Generated/_Note.h
@@ -1,49 +1,70 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to Note.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "ARManagedObject.h"
 
-extern const struct NoteAttributes {
-    __unsafe_unretained NSString *body;
-    __unsafe_unretained NSString *createdAt;
-    __unsafe_unretained NSString *updatedAt;
-} NoteAttributes;
-
-extern const struct NoteRelationships {
-    __unsafe_unretained NSString *artwork;
-} NoteRelationships;
-
-extern const struct NoteUserInfo {
-} NoteUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 @class Artwork;
 
 
-@interface NoteID : ARManagedObjectID {
+@interface NoteID : NSManagedObjectID
+{
 }
 @end
 
 
-@interface _Note : ARManagedObject {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _Note : ARManagedObject
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (NoteID *)objectID;
+@property (nonatomic, readonly, strong) NoteID *objectID;
 
 @property (nonatomic, strong) NSString *body;
-@property (nonatomic, strong) NSDate *createdAt;
-@property (nonatomic, strong) NSDate *updatedAt;
-@property (nonatomic, strong) Artwork *artwork;
 
+@property (nonatomic, strong, nullable) NSDate *createdAt;
+
+@property (nonatomic, strong, nullable) NSDate *updatedAt;
+
+@property (nonatomic, strong) Artwork *artwork;
 
 @end
 
 
 @interface _Note (CoreDataGeneratedPrimitiveAccessors)
 
+- (NSString *)primitiveBody;
+- (void)setPrimitiveBody:(NSString *)value;
+
+- (NSDate *)primitiveCreatedAt;
+- (void)setPrimitiveCreatedAt:(NSDate *)value;
+
+- (NSDate *)primitiveUpdatedAt;
+- (void)setPrimitiveUpdatedAt:(NSDate *)value;
+
 - (Artwork *)primitiveArtwork;
 - (void)setPrimitiveArtwork:(Artwork *)value;
 
 @end
+
+
+@interface NoteAttributes : NSObject
++ (NSString *)body;
++ (NSString *)createdAt;
++ (NSString *)updatedAt;
+@end
+
+
+@interface NoteRelationships : NSObject
++ (NSString *)artwork;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_Note.m
+++ b/Classes/Models/Generated/_Note.m
@@ -3,18 +3,6 @@
 
 #import "_Note.h"
 
-const struct NoteAttributes NoteAttributes = {
-    .body = @"body",
-    .createdAt = @"createdAt",
-    .updatedAt = @"updatedAt",
-};
-
-const struct NoteRelationships NoteRelationships = {
-    .artwork = @"artwork",
-};
-
-const struct NoteUserInfo NoteUserInfo = {};
-
 
 @implementation NoteID
 @end
@@ -22,7 +10,7 @@ const struct NoteUserInfo NoteUserInfo = {};
 
 @implementation _Note
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"Note" inManagedObjectContext:moc_];
@@ -44,13 +32,43 @@ const struct NoteUserInfo NoteUserInfo = {};
     return (NoteID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    return keyPaths;
+}
 
 @dynamic body;
-@dynamic createdAt;
-@dynamic updatedAt;
 
+@dynamic createdAt;
+
+@dynamic updatedAt;
 
 @dynamic artwork;
 
+@end
 
+
+@implementation NoteAttributes
++ (NSString *)body
+{
+    return @"body";
+}
++ (NSString *)createdAt
+{
+    return @"createdAt";
+}
++ (NSString *)updatedAt
+{
+    return @"updatedAt";
+}
+@end
+
+
+@implementation NoteRelationships
++ (NSString *)artwork
+{
+    return @"artwork";
+}
 @end

--- a/Classes/Models/Generated/_Partner.h
+++ b/Classes/Models/Generated/_Partner.h
@@ -1,46 +1,17 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to Partner.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "ARManagedObject.h"
 
-extern const struct PartnerAttributes {
-    __unsafe_unretained NSString *active;
-    __unsafe_unretained NSString *artistDocumentsCount;
-    __unsafe_unretained NSString *artistsCount;
-    __unsafe_unretained NSString *artworksCount;
-    __unsafe_unretained NSString *contractType;
-    __unsafe_unretained NSString *createdAt;
-    __unsafe_unretained NSString *defaultProfileID;
-    __unsafe_unretained NSString *defaultProfilePublic;
-    __unsafe_unretained NSString *directlyContactable;
-    __unsafe_unretained NSString *email;
-    __unsafe_unretained NSString *foundingPartner;
-    __unsafe_unretained NSString *hasDefaultProfile;
-    __unsafe_unretained NSString *hasFullProfile;
-    __unsafe_unretained NSString *name;
-    __unsafe_unretained NSString *partnerID;
-    __unsafe_unretained NSString *partnerLimitedAccess;
-    __unsafe_unretained NSString *partnerType;
-    __unsafe_unretained NSString *region;
-    __unsafe_unretained NSString *representativeEmail;
-    __unsafe_unretained NSString *showDocumentsCount;
-    __unsafe_unretained NSString *size;
-    __unsafe_unretained NSString *slug;
-    __unsafe_unretained NSString *subscriptionState;
-    __unsafe_unretained NSString *updatedAt;
-    __unsafe_unretained NSString *website;
-} PartnerAttributes;
-
-extern const struct PartnerRelationships {
-    __unsafe_unretained NSString *admin;
-    __unsafe_unretained NSString *artworks;
-    __unsafe_unretained NSString *flags;
-    __unsafe_unretained NSString *subscriptionPlans;
-} PartnerRelationships;
-
-extern const struct PartnerUserInfo {
-} PartnerUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 @class User;
 @class Artwork;
@@ -48,94 +19,319 @@ extern const struct PartnerUserInfo {
 @class SubscriptionPlan;
 
 
-@interface PartnerID : ARManagedObjectID {
+@interface PartnerID : NSManagedObjectID
+{
 }
 @end
 
 
-@interface _Partner : ARManagedObject {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _Partner : ARManagedObject
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (PartnerID *)objectID;
+@property (nonatomic, readonly, strong) PartnerID *objectID;
 
-@property (nonatomic, strong) NSNumber *active;
-@property (nonatomic, strong) NSNumber *artistDocumentsCount;
-@property (nonatomic, strong) NSNumber *artistsCount;
-@property (nonatomic, strong) NSNumber *artworksCount;
-@property (nonatomic, strong) NSString *contractType;
-@property (nonatomic, strong) NSDate *createdAt;
-@property (nonatomic, strong) NSString *defaultProfileID;
-@property (nonatomic, strong) NSNumber *defaultProfilePublic;
-@property (nonatomic, strong) NSNumber *directlyContactable;
-@property (nonatomic, strong) NSString *email;
-@property (nonatomic, strong) NSNumber *foundingPartner;
-@property (nonatomic, strong) NSNumber *hasDefaultProfile;
-@property (nonatomic, strong) NSNumber *hasFullProfile;
-@property (nonatomic, strong) NSString *name;
-@property (nonatomic, strong) NSString *partnerID;
-@property (nonatomic, strong) NSNumber *partnerLimitedAccess;
-@property (nonatomic, strong) NSString *partnerType;
-@property (nonatomic, strong) NSString *region;
-@property (nonatomic, strong) NSString *representativeEmail;
-@property (nonatomic, strong) NSNumber *showDocumentsCount;
-@property (nonatomic, strong) NSNumber *size;
-@property (nonatomic, strong) NSString *slug;
-@property (nonatomic, strong) NSString *subscriptionState;
-@property (nonatomic, strong) NSDate *updatedAt;
-@property (nonatomic, strong) NSString *website;
-@property (nonatomic, strong) User *admin;
+@property (nonatomic, strong, nullable) NSNumber *active;
 
-@property (nonatomic, strong) NSSet *artworks;
-- (NSMutableSet *)artworksSet;
+@property (atomic) BOOL activeValue;
+- (BOOL)activeValue;
+- (void)setActiveValue:(BOOL)value_;
 
-@property (nonatomic, strong) NSSet *flags;
-- (NSMutableSet *)flagsSet;
+@property (nonatomic, strong, nullable) NSNumber *artistDocumentsCount;
 
-@property (nonatomic, strong) NSSet *subscriptionPlans;
-- (NSMutableSet *)subscriptionPlansSet;
+@property (atomic) int32_t artistDocumentsCountValue;
+- (int32_t)artistDocumentsCountValue;
+- (void)setArtistDocumentsCountValue:(int32_t)value_;
 
+@property (nonatomic, strong, nullable) NSNumber *artistsCount;
+
+@property (atomic) int32_t artistsCountValue;
+- (int32_t)artistsCountValue;
+- (void)setArtistsCountValue:(int32_t)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *artworksCount;
+
+@property (atomic) int32_t artworksCountValue;
+- (int32_t)artworksCountValue;
+- (void)setArtworksCountValue:(int32_t)value_;
+
+@property (nonatomic, strong, nullable) NSString *contractType;
+
+@property (nonatomic, strong, nullable) NSDate *createdAt;
+
+@property (nonatomic, strong, nullable) NSString *defaultProfileID;
+
+@property (nonatomic, strong, nullable) NSNumber *defaultProfilePublic;
+
+@property (atomic) BOOL defaultProfilePublicValue;
+- (BOOL)defaultProfilePublicValue;
+- (void)setDefaultProfilePublicValue:(BOOL)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *directlyContactable;
+
+@property (atomic) BOOL directlyContactableValue;
+- (BOOL)directlyContactableValue;
+- (void)setDirectlyContactableValue:(BOOL)value_;
+
+@property (nonatomic, strong, nullable) NSString *email;
+
+@property (nonatomic, strong, nullable) NSNumber *foundingPartner;
+
+@property (atomic) BOOL foundingPartnerValue;
+- (BOOL)foundingPartnerValue;
+- (void)setFoundingPartnerValue:(BOOL)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *hasDefaultProfile;
+
+@property (atomic) BOOL hasDefaultProfileValue;
+- (BOOL)hasDefaultProfileValue;
+- (void)setHasDefaultProfileValue:(BOOL)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *hasFullProfile;
+
+@property (atomic) BOOL hasFullProfileValue;
+- (BOOL)hasFullProfileValue;
+- (void)setHasFullProfileValue:(BOOL)value_;
+
+@property (nonatomic, strong, nullable) NSString *name;
+
+@property (nonatomic, strong, nullable) NSString *partnerID;
+
+@property (nonatomic, strong, nullable) NSNumber *partnerLimitedAccess;
+
+@property (atomic) BOOL partnerLimitedAccessValue;
+- (BOOL)partnerLimitedAccessValue;
+- (void)setPartnerLimitedAccessValue:(BOOL)value_;
+
+@property (nonatomic, strong, nullable) NSString *partnerType;
+
+@property (nonatomic, strong, nullable) NSString *region;
+
+@property (nonatomic, strong, nullable) NSString *representativeEmail;
+
+@property (nonatomic, strong, nullable) NSNumber *showDocumentsCount;
+
+@property (atomic) int32_t showDocumentsCountValue;
+- (int32_t)showDocumentsCountValue;
+- (void)setShowDocumentsCountValue:(int32_t)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *size;
+
+@property (atomic) int16_t sizeValue;
+- (int16_t)sizeValue;
+- (void)setSizeValue:(int16_t)value_;
+
+@property (nonatomic, strong, nullable) NSString *slug;
+
+@property (nonatomic, strong, nullable) NSString *subscriptionState;
+
+@property (nonatomic, strong, nullable) NSDate *updatedAt;
+
+@property (nonatomic, strong, nullable) NSString *website;
+
+@property (nonatomic, strong, nullable) User *admin;
+
+@property (nonatomic, strong, nullable) NSSet<Artwork *> *artworks;
+- (nullable NSMutableSet<Artwork *> *)artworksSet;
+
+@property (nonatomic, strong, nullable) NSSet<PartnerOption *> *flags;
+- (nullable NSMutableSet<PartnerOption *> *)flagsSet;
+
+@property (nonatomic, strong, nullable) NSSet<SubscriptionPlan *> *subscriptionPlans;
+- (nullable NSMutableSet<SubscriptionPlan *> *)subscriptionPlansSet;
 
 @end
 
 
 @interface _Partner (ArtworksCoreDataGeneratedAccessors)
-- (void)addArtworks:(NSSet *)value_;
-- (void)removeArtworks:(NSSet *)value_;
+- (void)addArtworks:(NSSet<Artwork *> *)value_;
+- (void)removeArtworks:(NSSet<Artwork *> *)value_;
 - (void)addArtworksObject:(Artwork *)value_;
 - (void)removeArtworksObject:(Artwork *)value_;
+
 @end
 
 
 @interface _Partner (FlagsCoreDataGeneratedAccessors)
-- (void)addFlags:(NSSet *)value_;
-- (void)removeFlags:(NSSet *)value_;
+- (void)addFlags:(NSSet<PartnerOption *> *)value_;
+- (void)removeFlags:(NSSet<PartnerOption *> *)value_;
 - (void)addFlagsObject:(PartnerOption *)value_;
 - (void)removeFlagsObject:(PartnerOption *)value_;
+
 @end
 
 
 @interface _Partner (SubscriptionPlansCoreDataGeneratedAccessors)
-- (void)addSubscriptionPlans:(NSSet *)value_;
-- (void)removeSubscriptionPlans:(NSSet *)value_;
+- (void)addSubscriptionPlans:(NSSet<SubscriptionPlan *> *)value_;
+- (void)removeSubscriptionPlans:(NSSet<SubscriptionPlan *> *)value_;
 - (void)addSubscriptionPlansObject:(SubscriptionPlan *)value_;
 - (void)removeSubscriptionPlansObject:(SubscriptionPlan *)value_;
+
 @end
 
 
 @interface _Partner (CoreDataGeneratedPrimitiveAccessors)
 
+- (NSNumber *)primitiveActive;
+- (void)setPrimitiveActive:(NSNumber *)value;
+
+- (BOOL)primitiveActiveValue;
+- (void)setPrimitiveActiveValue:(BOOL)value_;
+
+- (NSNumber *)primitiveArtistDocumentsCount;
+- (void)setPrimitiveArtistDocumentsCount:(NSNumber *)value;
+
+- (int32_t)primitiveArtistDocumentsCountValue;
+- (void)setPrimitiveArtistDocumentsCountValue:(int32_t)value_;
+
+- (NSNumber *)primitiveArtistsCount;
+- (void)setPrimitiveArtistsCount:(NSNumber *)value;
+
+- (int32_t)primitiveArtistsCountValue;
+- (void)setPrimitiveArtistsCountValue:(int32_t)value_;
+
+- (NSNumber *)primitiveArtworksCount;
+- (void)setPrimitiveArtworksCount:(NSNumber *)value;
+
+- (int32_t)primitiveArtworksCountValue;
+- (void)setPrimitiveArtworksCountValue:(int32_t)value_;
+
+- (NSString *)primitiveContractType;
+- (void)setPrimitiveContractType:(NSString *)value;
+
+- (NSDate *)primitiveCreatedAt;
+- (void)setPrimitiveCreatedAt:(NSDate *)value;
+
+- (NSString *)primitiveDefaultProfileID;
+- (void)setPrimitiveDefaultProfileID:(NSString *)value;
+
+- (NSNumber *)primitiveDefaultProfilePublic;
+- (void)setPrimitiveDefaultProfilePublic:(NSNumber *)value;
+
+- (BOOL)primitiveDefaultProfilePublicValue;
+- (void)setPrimitiveDefaultProfilePublicValue:(BOOL)value_;
+
+- (NSNumber *)primitiveDirectlyContactable;
+- (void)setPrimitiveDirectlyContactable:(NSNumber *)value;
+
+- (BOOL)primitiveDirectlyContactableValue;
+- (void)setPrimitiveDirectlyContactableValue:(BOOL)value_;
+
+- (NSString *)primitiveEmail;
+- (void)setPrimitiveEmail:(NSString *)value;
+
+- (NSNumber *)primitiveFoundingPartner;
+- (void)setPrimitiveFoundingPartner:(NSNumber *)value;
+
+- (BOOL)primitiveFoundingPartnerValue;
+- (void)setPrimitiveFoundingPartnerValue:(BOOL)value_;
+
+- (NSNumber *)primitiveHasDefaultProfile;
+- (void)setPrimitiveHasDefaultProfile:(NSNumber *)value;
+
+- (BOOL)primitiveHasDefaultProfileValue;
+- (void)setPrimitiveHasDefaultProfileValue:(BOOL)value_;
+
+- (NSNumber *)primitiveHasFullProfile;
+- (void)setPrimitiveHasFullProfile:(NSNumber *)value;
+
+- (BOOL)primitiveHasFullProfileValue;
+- (void)setPrimitiveHasFullProfileValue:(BOOL)value_;
+
+- (NSString *)primitiveName;
+- (void)setPrimitiveName:(NSString *)value;
+
+- (NSString *)primitivePartnerID;
+- (void)setPrimitivePartnerID:(NSString *)value;
+
+- (NSNumber *)primitivePartnerLimitedAccess;
+- (void)setPrimitivePartnerLimitedAccess:(NSNumber *)value;
+
+- (BOOL)primitivePartnerLimitedAccessValue;
+- (void)setPrimitivePartnerLimitedAccessValue:(BOOL)value_;
+
+- (NSString *)primitivePartnerType;
+- (void)setPrimitivePartnerType:(NSString *)value;
+
+- (NSString *)primitiveRegion;
+- (void)setPrimitiveRegion:(NSString *)value;
+
+- (NSString *)primitiveRepresentativeEmail;
+- (void)setPrimitiveRepresentativeEmail:(NSString *)value;
+
+- (NSNumber *)primitiveShowDocumentsCount;
+- (void)setPrimitiveShowDocumentsCount:(NSNumber *)value;
+
+- (int32_t)primitiveShowDocumentsCountValue;
+- (void)setPrimitiveShowDocumentsCountValue:(int32_t)value_;
+
+- (NSNumber *)primitiveSize;
+- (void)setPrimitiveSize:(NSNumber *)value;
+
+- (int16_t)primitiveSizeValue;
+- (void)setPrimitiveSizeValue:(int16_t)value_;
+
+- (NSString *)primitiveSlug;
+- (void)setPrimitiveSlug:(NSString *)value;
+
+- (NSString *)primitiveSubscriptionState;
+- (void)setPrimitiveSubscriptionState:(NSString *)value;
+
+- (NSDate *)primitiveUpdatedAt;
+- (void)setPrimitiveUpdatedAt:(NSDate *)value;
+
+- (NSString *)primitiveWebsite;
+- (void)setPrimitiveWebsite:(NSString *)value;
+
 - (User *)primitiveAdmin;
 - (void)setPrimitiveAdmin:(User *)value;
 
-- (NSMutableSet *)primitiveArtworks;
-- (void)setPrimitiveArtworks:(NSMutableSet *)value;
+- (NSMutableSet<Artwork *> *)primitiveArtworks;
+- (void)setPrimitiveArtworks:(NSMutableSet<Artwork *> *)value;
 
-- (NSMutableSet *)primitiveFlags;
-- (void)setPrimitiveFlags:(NSMutableSet *)value;
+- (NSMutableSet<PartnerOption *> *)primitiveFlags;
+- (void)setPrimitiveFlags:(NSMutableSet<PartnerOption *> *)value;
 
-- (NSMutableSet *)primitiveSubscriptionPlans;
-- (void)setPrimitiveSubscriptionPlans:(NSMutableSet *)value;
+- (NSMutableSet<SubscriptionPlan *> *)primitiveSubscriptionPlans;
+- (void)setPrimitiveSubscriptionPlans:(NSMutableSet<SubscriptionPlan *> *)value;
 
 @end
+
+
+@interface PartnerAttributes : NSObject
++ (NSString *)active;
++ (NSString *)artistDocumentsCount;
++ (NSString *)artistsCount;
++ (NSString *)artworksCount;
++ (NSString *)contractType;
++ (NSString *)createdAt;
++ (NSString *)defaultProfileID;
++ (NSString *)defaultProfilePublic;
++ (NSString *)directlyContactable;
++ (NSString *)email;
++ (NSString *)foundingPartner;
++ (NSString *)hasDefaultProfile;
++ (NSString *)hasFullProfile;
++ (NSString *)name;
++ (NSString *)partnerID;
++ (NSString *)partnerLimitedAccess;
++ (NSString *)partnerType;
++ (NSString *)region;
++ (NSString *)representativeEmail;
++ (NSString *)showDocumentsCount;
++ (NSString *)size;
++ (NSString *)slug;
++ (NSString *)subscriptionState;
++ (NSString *)updatedAt;
++ (NSString *)website;
+@end
+
+
+@interface PartnerRelationships : NSObject
++ (NSString *)admin;
++ (NSString *)artworks;
++ (NSString *)flags;
++ (NSString *)subscriptionPlans;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_Partner.m
+++ b/Classes/Models/Generated/_Partner.m
@@ -3,43 +3,6 @@
 
 #import "_Partner.h"
 
-const struct PartnerAttributes PartnerAttributes = {
-    .active = @"active",
-    .artistDocumentsCount = @"artistDocumentsCount",
-    .artistsCount = @"artistsCount",
-    .artworksCount = @"artworksCount",
-    .contractType = @"contractType",
-    .createdAt = @"createdAt",
-    .defaultProfileID = @"defaultProfileID",
-    .defaultProfilePublic = @"defaultProfilePublic",
-    .directlyContactable = @"directlyContactable",
-    .email = @"email",
-    .foundingPartner = @"foundingPartner",
-    .hasDefaultProfile = @"hasDefaultProfile",
-    .hasFullProfile = @"hasFullProfile",
-    .name = @"name",
-    .partnerID = @"partnerID",
-    .partnerLimitedAccess = @"partnerLimitedAccess",
-    .partnerType = @"partnerType",
-    .region = @"region",
-    .representativeEmail = @"representativeEmail",
-    .showDocumentsCount = @"showDocumentsCount",
-    .size = @"size",
-    .slug = @"slug",
-    .subscriptionState = @"subscriptionState",
-    .updatedAt = @"updatedAt",
-    .website = @"website",
-};
-
-const struct PartnerRelationships PartnerRelationships = {
-    .admin = @"admin",
-    .artworks = @"artworks",
-    .flags = @"flags",
-    .subscriptionPlans = @"subscriptionPlans",
-};
-
-const struct PartnerUserInfo PartnerUserInfo = {};
-
 
 @implementation PartnerID
 @end
@@ -47,7 +10,7 @@ const struct PartnerUserInfo PartnerUserInfo = {};
 
 @implementation _Partner
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"Partner" inManagedObjectContext:moc_];
@@ -69,61 +32,548 @@ const struct PartnerUserInfo PartnerUserInfo = {};
     return (PartnerID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    if ([key isEqualToString:@"activeValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"active"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"artistDocumentsCountValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"artistDocumentsCount"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"artistsCountValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"artistsCount"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"artworksCountValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"artworksCount"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"defaultProfilePublicValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"defaultProfilePublic"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"directlyContactableValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"directlyContactable"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"foundingPartnerValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"foundingPartner"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"hasDefaultProfileValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"hasDefaultProfile"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"hasFullProfileValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"hasFullProfile"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"partnerLimitedAccessValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"partnerLimitedAccess"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"showDocumentsCountValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"showDocumentsCount"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"sizeValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"size"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+
+    return keyPaths;
+}
 
 @dynamic active;
+
+- (BOOL)activeValue
+{
+    NSNumber *result = [self active];
+    return [result boolValue];
+}
+
+- (void)setActiveValue:(BOOL)value_
+{
+    [self setActive:@(value_)];
+}
+
+- (BOOL)primitiveActiveValue
+{
+    NSNumber *result = [self primitiveActive];
+    return [result boolValue];
+}
+
+- (void)setPrimitiveActiveValue:(BOOL)value_
+{
+    [self setPrimitiveActive:@(value_)];
+}
+
 @dynamic artistDocumentsCount;
+
+- (int32_t)artistDocumentsCountValue
+{
+    NSNumber *result = [self artistDocumentsCount];
+    return [result intValue];
+}
+
+- (void)setArtistDocumentsCountValue:(int32_t)value_
+{
+    [self setArtistDocumentsCount:@(value_)];
+}
+
+- (int32_t)primitiveArtistDocumentsCountValue
+{
+    NSNumber *result = [self primitiveArtistDocumentsCount];
+    return [result intValue];
+}
+
+- (void)setPrimitiveArtistDocumentsCountValue:(int32_t)value_
+{
+    [self setPrimitiveArtistDocumentsCount:@(value_)];
+}
+
 @dynamic artistsCount;
+
+- (int32_t)artistsCountValue
+{
+    NSNumber *result = [self artistsCount];
+    return [result intValue];
+}
+
+- (void)setArtistsCountValue:(int32_t)value_
+{
+    [self setArtistsCount:@(value_)];
+}
+
+- (int32_t)primitiveArtistsCountValue
+{
+    NSNumber *result = [self primitiveArtistsCount];
+    return [result intValue];
+}
+
+- (void)setPrimitiveArtistsCountValue:(int32_t)value_
+{
+    [self setPrimitiveArtistsCount:@(value_)];
+}
+
 @dynamic artworksCount;
+
+- (int32_t)artworksCountValue
+{
+    NSNumber *result = [self artworksCount];
+    return [result intValue];
+}
+
+- (void)setArtworksCountValue:(int32_t)value_
+{
+    [self setArtworksCount:@(value_)];
+}
+
+- (int32_t)primitiveArtworksCountValue
+{
+    NSNumber *result = [self primitiveArtworksCount];
+    return [result intValue];
+}
+
+- (void)setPrimitiveArtworksCountValue:(int32_t)value_
+{
+    [self setPrimitiveArtworksCount:@(value_)];
+}
+
 @dynamic contractType;
+
 @dynamic createdAt;
+
 @dynamic defaultProfileID;
+
 @dynamic defaultProfilePublic;
+
+- (BOOL)defaultProfilePublicValue
+{
+    NSNumber *result = [self defaultProfilePublic];
+    return [result boolValue];
+}
+
+- (void)setDefaultProfilePublicValue:(BOOL)value_
+{
+    [self setDefaultProfilePublic:@(value_)];
+}
+
+- (BOOL)primitiveDefaultProfilePublicValue
+{
+    NSNumber *result = [self primitiveDefaultProfilePublic];
+    return [result boolValue];
+}
+
+- (void)setPrimitiveDefaultProfilePublicValue:(BOOL)value_
+{
+    [self setPrimitiveDefaultProfilePublic:@(value_)];
+}
+
 @dynamic directlyContactable;
+
+- (BOOL)directlyContactableValue
+{
+    NSNumber *result = [self directlyContactable];
+    return [result boolValue];
+}
+
+- (void)setDirectlyContactableValue:(BOOL)value_
+{
+    [self setDirectlyContactable:@(value_)];
+}
+
+- (BOOL)primitiveDirectlyContactableValue
+{
+    NSNumber *result = [self primitiveDirectlyContactable];
+    return [result boolValue];
+}
+
+- (void)setPrimitiveDirectlyContactableValue:(BOOL)value_
+{
+    [self setPrimitiveDirectlyContactable:@(value_)];
+}
+
 @dynamic email;
+
 @dynamic foundingPartner;
+
+- (BOOL)foundingPartnerValue
+{
+    NSNumber *result = [self foundingPartner];
+    return [result boolValue];
+}
+
+- (void)setFoundingPartnerValue:(BOOL)value_
+{
+    [self setFoundingPartner:@(value_)];
+}
+
+- (BOOL)primitiveFoundingPartnerValue
+{
+    NSNumber *result = [self primitiveFoundingPartner];
+    return [result boolValue];
+}
+
+- (void)setPrimitiveFoundingPartnerValue:(BOOL)value_
+{
+    [self setPrimitiveFoundingPartner:@(value_)];
+}
+
 @dynamic hasDefaultProfile;
+
+- (BOOL)hasDefaultProfileValue
+{
+    NSNumber *result = [self hasDefaultProfile];
+    return [result boolValue];
+}
+
+- (void)setHasDefaultProfileValue:(BOOL)value_
+{
+    [self setHasDefaultProfile:@(value_)];
+}
+
+- (BOOL)primitiveHasDefaultProfileValue
+{
+    NSNumber *result = [self primitiveHasDefaultProfile];
+    return [result boolValue];
+}
+
+- (void)setPrimitiveHasDefaultProfileValue:(BOOL)value_
+{
+    [self setPrimitiveHasDefaultProfile:@(value_)];
+}
+
 @dynamic hasFullProfile;
+
+- (BOOL)hasFullProfileValue
+{
+    NSNumber *result = [self hasFullProfile];
+    return [result boolValue];
+}
+
+- (void)setHasFullProfileValue:(BOOL)value_
+{
+    [self setHasFullProfile:@(value_)];
+}
+
+- (BOOL)primitiveHasFullProfileValue
+{
+    NSNumber *result = [self primitiveHasFullProfile];
+    return [result boolValue];
+}
+
+- (void)setPrimitiveHasFullProfileValue:(BOOL)value_
+{
+    [self setPrimitiveHasFullProfile:@(value_)];
+}
+
 @dynamic name;
+
 @dynamic partnerID;
+
 @dynamic partnerLimitedAccess;
+
+- (BOOL)partnerLimitedAccessValue
+{
+    NSNumber *result = [self partnerLimitedAccess];
+    return [result boolValue];
+}
+
+- (void)setPartnerLimitedAccessValue:(BOOL)value_
+{
+    [self setPartnerLimitedAccess:@(value_)];
+}
+
+- (BOOL)primitivePartnerLimitedAccessValue
+{
+    NSNumber *result = [self primitivePartnerLimitedAccess];
+    return [result boolValue];
+}
+
+- (void)setPrimitivePartnerLimitedAccessValue:(BOOL)value_
+{
+    [self setPrimitivePartnerLimitedAccess:@(value_)];
+}
+
 @dynamic partnerType;
+
 @dynamic region;
+
 @dynamic representativeEmail;
+
 @dynamic showDocumentsCount;
+
+- (int32_t)showDocumentsCountValue
+{
+    NSNumber *result = [self showDocumentsCount];
+    return [result intValue];
+}
+
+- (void)setShowDocumentsCountValue:(int32_t)value_
+{
+    [self setShowDocumentsCount:@(value_)];
+}
+
+- (int32_t)primitiveShowDocumentsCountValue
+{
+    NSNumber *result = [self primitiveShowDocumentsCount];
+    return [result intValue];
+}
+
+- (void)setPrimitiveShowDocumentsCountValue:(int32_t)value_
+{
+    [self setPrimitiveShowDocumentsCount:@(value_)];
+}
+
 @dynamic size;
+
+- (int16_t)sizeValue
+{
+    NSNumber *result = [self size];
+    return [result shortValue];
+}
+
+- (void)setSizeValue:(int16_t)value_
+{
+    [self setSize:@(value_)];
+}
+
+- (int16_t)primitiveSizeValue
+{
+    NSNumber *result = [self primitiveSize];
+    return [result shortValue];
+}
+
+- (void)setPrimitiveSizeValue:(int16_t)value_
+{
+    [self setPrimitiveSize:@(value_)];
+}
+
 @dynamic slug;
+
 @dynamic subscriptionState;
+
 @dynamic updatedAt;
+
 @dynamic website;
 
-
 @dynamic admin;
+
 @dynamic artworks;
-- (NSMutableSet *)artworksSet
+
+- (NSMutableSet<Artwork *> *)artworksSet
 {
     [self willAccessValueForKey:@"artworks"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"artworks"];
+
+    NSMutableSet<Artwork *> *result = (NSMutableSet<Artwork *> *)[self mutableSetValueForKey:@"artworks"];
+
     [self didAccessValueForKey:@"artworks"];
     return result;
 }
 
 @dynamic flags;
-- (NSMutableSet *)flagsSet
+
+- (NSMutableSet<PartnerOption *> *)flagsSet
 {
     [self willAccessValueForKey:@"flags"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"flags"];
+
+    NSMutableSet<PartnerOption *> *result = (NSMutableSet<PartnerOption *> *)[self mutableSetValueForKey:@"flags"];
+
     [self didAccessValueForKey:@"flags"];
     return result;
 }
 
 @dynamic subscriptionPlans;
-- (NSMutableSet *)subscriptionPlansSet
+
+- (NSMutableSet<SubscriptionPlan *> *)subscriptionPlansSet
 {
     [self willAccessValueForKey:@"subscriptionPlans"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"subscriptionPlans"];
+
+    NSMutableSet<SubscriptionPlan *> *result = (NSMutableSet<SubscriptionPlan *> *)[self mutableSetValueForKey:@"subscriptionPlans"];
+
     [self didAccessValueForKey:@"subscriptionPlans"];
     return result;
 }
 
+@end
 
+
+@implementation PartnerAttributes
++ (NSString *)active
+{
+    return @"active";
+}
++ (NSString *)artistDocumentsCount
+{
+    return @"artistDocumentsCount";
+}
++ (NSString *)artistsCount
+{
+    return @"artistsCount";
+}
++ (NSString *)artworksCount
+{
+    return @"artworksCount";
+}
++ (NSString *)contractType
+{
+    return @"contractType";
+}
++ (NSString *)createdAt
+{
+    return @"createdAt";
+}
++ (NSString *)defaultProfileID
+{
+    return @"defaultProfileID";
+}
++ (NSString *)defaultProfilePublic
+{
+    return @"defaultProfilePublic";
+}
++ (NSString *)directlyContactable
+{
+    return @"directlyContactable";
+}
++ (NSString *)email
+{
+    return @"email";
+}
++ (NSString *)foundingPartner
+{
+    return @"foundingPartner";
+}
++ (NSString *)hasDefaultProfile
+{
+    return @"hasDefaultProfile";
+}
++ (NSString *)hasFullProfile
+{
+    return @"hasFullProfile";
+}
++ (NSString *)name
+{
+    return @"name";
+}
++ (NSString *)partnerID
+{
+    return @"partnerID";
+}
++ (NSString *)partnerLimitedAccess
+{
+    return @"partnerLimitedAccess";
+}
++ (NSString *)partnerType
+{
+    return @"partnerType";
+}
++ (NSString *)region
+{
+    return @"region";
+}
++ (NSString *)representativeEmail
+{
+    return @"representativeEmail";
+}
++ (NSString *)showDocumentsCount
+{
+    return @"showDocumentsCount";
+}
++ (NSString *)size
+{
+    return @"size";
+}
++ (NSString *)slug
+{
+    return @"slug";
+}
++ (NSString *)subscriptionState
+{
+    return @"subscriptionState";
+}
++ (NSString *)updatedAt
+{
+    return @"updatedAt";
+}
++ (NSString *)website
+{
+    return @"website";
+}
+@end
+
+
+@implementation PartnerRelationships
++ (NSString *)admin
+{
+    return @"admin";
+}
++ (NSString *)artworks
+{
+    return @"artworks";
+}
++ (NSString *)flags
+{
+    return @"flags";
+}
++ (NSString *)subscriptionPlans
+{
+    return @"subscriptionPlans";
+}
 @end

--- a/Classes/Models/Generated/_PartnerOption.h
+++ b/Classes/Models/Generated/_PartnerOption.h
@@ -1,47 +1,64 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to PartnerOption.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "ARManagedObject.h"
 
-extern const struct PartnerOptionAttributes {
-    __unsafe_unretained NSString *key;
-    __unsafe_unretained NSString *value;
-} PartnerOptionAttributes;
-
-extern const struct PartnerOptionRelationships {
-    __unsafe_unretained NSString *partner;
-} PartnerOptionRelationships;
-
-extern const struct PartnerOptionUserInfo {
-} PartnerOptionUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 @class Partner;
 
 
-@interface PartnerOptionID : ARManagedObjectID {
+@interface PartnerOptionID : NSManagedObjectID
+{
 }
 @end
 
 
-@interface _PartnerOption : ARManagedObject {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _PartnerOption : ARManagedObject
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (PartnerOptionID *)objectID;
+@property (nonatomic, readonly, strong) PartnerOptionID *objectID;
 
-@property (nonatomic, strong) NSString *key;
-@property (nonatomic, strong) NSString *value;
-@property (nonatomic, strong) Partner *partner;
+@property (nonatomic, strong, nullable) NSString *key;
 
+@property (nonatomic, strong, nullable) NSString *value;
+
+@property (nonatomic, strong, nullable) Partner *partner;
 
 @end
 
 
 @interface _PartnerOption (CoreDataGeneratedPrimitiveAccessors)
 
+- (NSString *)primitiveKey;
+- (void)setPrimitiveKey:(NSString *)value;
+
+- (NSString *)primitiveValue;
+- (void)setPrimitiveValue:(NSString *)value;
+
 - (Partner *)primitivePartner;
 - (void)setPrimitivePartner:(Partner *)value;
 
 @end
+
+
+@interface PartnerOptionAttributes : NSObject
++ (NSString *)key;
++ (NSString *)value;
+@end
+
+
+@interface PartnerOptionRelationships : NSObject
++ (NSString *)partner;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_PartnerOption.m
+++ b/Classes/Models/Generated/_PartnerOption.m
@@ -3,17 +3,6 @@
 
 #import "_PartnerOption.h"
 
-const struct PartnerOptionAttributes PartnerOptionAttributes = {
-    .key = @"key",
-    .value = @"value",
-};
-
-const struct PartnerOptionRelationships PartnerOptionRelationships = {
-    .partner = @"partner",
-};
-
-const struct PartnerOptionUserInfo PartnerOptionUserInfo = {};
-
 
 @implementation PartnerOptionID
 @end
@@ -21,7 +10,7 @@ const struct PartnerOptionUserInfo PartnerOptionUserInfo = {};
 
 @implementation _PartnerOption
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"PartnerOption" inManagedObjectContext:moc_];
@@ -43,12 +32,37 @@ const struct PartnerOptionUserInfo PartnerOptionUserInfo = {};
     return (PartnerOptionID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    return keyPaths;
+}
 
 @dynamic key;
-@dynamic value;
 
+@dynamic value;
 
 @dynamic partner;
 
+@end
 
+
+@implementation PartnerOptionAttributes
++ (NSString *)key
+{
+    return @"key";
+}
++ (NSString *)value
+{
+    return @"value";
+}
+@end
+
+
+@implementation PartnerOptionRelationships
++ (NSString *)partner
+{
+    return @"partner";
+}
 @end

--- a/Classes/Models/Generated/_Show.h
+++ b/Classes/Models/Generated/_Show.h
@@ -1,33 +1,17 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to Show.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "ARManagedObject.h"
 
-extern const struct ShowAttributes {
-    __unsafe_unretained NSString *availabilityPeriod;
-    __unsafe_unretained NSString *createdAt;
-    __unsafe_unretained NSString *endsAt;
-    __unsafe_unretained NSString *name;
-    __unsafe_unretained NSString *showSlug;
-    __unsafe_unretained NSString *slug;
-    __unsafe_unretained NSString *sortKey;
-    __unsafe_unretained NSString *startsAt;
-    __unsafe_unretained NSString *status;
-    __unsafe_unretained NSString *updatedAt;
-} ShowAttributes;
-
-extern const struct ShowRelationships {
-    __unsafe_unretained NSString *artists;
-    __unsafe_unretained NSString *artworks;
-    __unsafe_unretained NSString *cover;
-    __unsafe_unretained NSString *documents;
-    __unsafe_unretained NSString *installationImages;
-    __unsafe_unretained NSString *location;
-} ShowRelationships;
-
-extern const struct ShowUserInfo {
-} ShowUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 @class Artist;
 @class Artwork;
@@ -37,97 +21,174 @@ extern const struct ShowUserInfo {
 @class Location;
 
 
-@interface ShowID : ARManagedObjectID {
+@interface ShowID : NSManagedObjectID
+{
 }
 @end
 
 
-@interface _Show : ARManagedObject {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _Show : ARManagedObject
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (ShowID *)objectID;
+@property (nonatomic, readonly, strong) ShowID *objectID;
 
-@property (nonatomic, strong) NSString *availabilityPeriod;
-@property (nonatomic, strong) NSString *createdAt;
-@property (nonatomic, strong) NSDate *endsAt;
-@property (nonatomic, strong) NSString *name;
-@property (nonatomic, strong) NSString *showSlug;
+@property (nonatomic, strong, nullable) NSString *availabilityPeriod;
+
+@property (nonatomic, strong, nullable) NSString *createdAt;
+
+@property (nonatomic, strong, nullable) NSDate *endsAt;
+
+@property (nonatomic, strong, nullable) NSString *name;
+
+@property (nonatomic, strong, nullable) NSString *showSlug;
+
 @property (nonatomic, strong) NSString *slug;
-@property (nonatomic, strong) NSNumber *sortKey;
-@property (nonatomic, strong) NSDate *startsAt;
-@property (nonatomic, strong) NSString *status;
-@property (nonatomic, strong) NSDate *updatedAt;
 
-@property (nonatomic, strong) NSSet *artists;
-- (NSMutableSet *)artistsSet;
+@property (nonatomic, strong, nullable) NSNumber *sortKey;
 
-@property (nonatomic, strong) NSSet *artworks;
-- (NSMutableSet *)artworksSet;
-@property (nonatomic, strong) Image *cover;
+@property (atomic) int16_t sortKeyValue;
+- (int16_t)sortKeyValue;
+- (void)setSortKeyValue:(int16_t)value_;
 
-@property (nonatomic, strong) NSSet *documents;
-- (NSMutableSet *)documentsSet;
+@property (nonatomic, strong, nullable) NSDate *startsAt;
 
-@property (nonatomic, strong) NSSet *installationImages;
-- (NSMutableSet *)installationImagesSet;
-@property (nonatomic, strong) Location *location;
+@property (nonatomic, strong, nullable) NSString *status;
 
+@property (nonatomic, strong, nullable) NSDate *updatedAt;
+
+@property (nonatomic, strong, nullable) NSSet<Artist *> *artists;
+- (nullable NSMutableSet<Artist *> *)artistsSet;
+
+@property (nonatomic, strong, nullable) NSSet<Artwork *> *artworks;
+- (nullable NSMutableSet<Artwork *> *)artworksSet;
+
+@property (nonatomic, strong, nullable) Image *cover;
+
+@property (nonatomic, strong, nullable) NSSet<Document *> *documents;
+- (nullable NSMutableSet<Document *> *)documentsSet;
+
+@property (nonatomic, strong, nullable) NSSet<InstallShotImage *> *installationImages;
+- (nullable NSMutableSet<InstallShotImage *> *)installationImagesSet;
+
+@property (nonatomic, strong, nullable) Location *location;
 
 @end
 
 
 @interface _Show (ArtistsCoreDataGeneratedAccessors)
-- (void)addArtists:(NSSet *)value_;
-- (void)removeArtists:(NSSet *)value_;
+- (void)addArtists:(NSSet<Artist *> *)value_;
+- (void)removeArtists:(NSSet<Artist *> *)value_;
 - (void)addArtistsObject:(Artist *)value_;
 - (void)removeArtistsObject:(Artist *)value_;
+
 @end
 
 
 @interface _Show (ArtworksCoreDataGeneratedAccessors)
-- (void)addArtworks:(NSSet *)value_;
-- (void)removeArtworks:(NSSet *)value_;
+- (void)addArtworks:(NSSet<Artwork *> *)value_;
+- (void)removeArtworks:(NSSet<Artwork *> *)value_;
 - (void)addArtworksObject:(Artwork *)value_;
 - (void)removeArtworksObject:(Artwork *)value_;
+
 @end
 
 
 @interface _Show (DocumentsCoreDataGeneratedAccessors)
-- (void)addDocuments:(NSSet *)value_;
-- (void)removeDocuments:(NSSet *)value_;
+- (void)addDocuments:(NSSet<Document *> *)value_;
+- (void)removeDocuments:(NSSet<Document *> *)value_;
 - (void)addDocumentsObject:(Document *)value_;
 - (void)removeDocumentsObject:(Document *)value_;
+
 @end
 
 
 @interface _Show (InstallationImagesCoreDataGeneratedAccessors)
-- (void)addInstallationImages:(NSSet *)value_;
-- (void)removeInstallationImages:(NSSet *)value_;
+- (void)addInstallationImages:(NSSet<InstallShotImage *> *)value_;
+- (void)removeInstallationImages:(NSSet<InstallShotImage *> *)value_;
 - (void)addInstallationImagesObject:(InstallShotImage *)value_;
 - (void)removeInstallationImagesObject:(InstallShotImage *)value_;
+
 @end
 
 
 @interface _Show (CoreDataGeneratedPrimitiveAccessors)
 
-- (NSMutableSet *)primitiveArtists;
-- (void)setPrimitiveArtists:(NSMutableSet *)value;
+- (NSString *)primitiveAvailabilityPeriod;
+- (void)setPrimitiveAvailabilityPeriod:(NSString *)value;
 
-- (NSMutableSet *)primitiveArtworks;
-- (void)setPrimitiveArtworks:(NSMutableSet *)value;
+- (NSString *)primitiveCreatedAt;
+- (void)setPrimitiveCreatedAt:(NSString *)value;
+
+- (NSDate *)primitiveEndsAt;
+- (void)setPrimitiveEndsAt:(NSDate *)value;
+
+- (NSString *)primitiveName;
+- (void)setPrimitiveName:(NSString *)value;
+
+- (NSString *)primitiveShowSlug;
+- (void)setPrimitiveShowSlug:(NSString *)value;
+
+- (NSString *)primitiveSlug;
+- (void)setPrimitiveSlug:(NSString *)value;
+
+- (NSNumber *)primitiveSortKey;
+- (void)setPrimitiveSortKey:(NSNumber *)value;
+
+- (int16_t)primitiveSortKeyValue;
+- (void)setPrimitiveSortKeyValue:(int16_t)value_;
+
+- (NSDate *)primitiveStartsAt;
+- (void)setPrimitiveStartsAt:(NSDate *)value;
+
+- (NSString *)primitiveStatus;
+- (void)setPrimitiveStatus:(NSString *)value;
+
+- (NSDate *)primitiveUpdatedAt;
+- (void)setPrimitiveUpdatedAt:(NSDate *)value;
+
+- (NSMutableSet<Artist *> *)primitiveArtists;
+- (void)setPrimitiveArtists:(NSMutableSet<Artist *> *)value;
+
+- (NSMutableSet<Artwork *> *)primitiveArtworks;
+- (void)setPrimitiveArtworks:(NSMutableSet<Artwork *> *)value;
 
 - (Image *)primitiveCover;
 - (void)setPrimitiveCover:(Image *)value;
 
-- (NSMutableSet *)primitiveDocuments;
-- (void)setPrimitiveDocuments:(NSMutableSet *)value;
+- (NSMutableSet<Document *> *)primitiveDocuments;
+- (void)setPrimitiveDocuments:(NSMutableSet<Document *> *)value;
 
-- (NSMutableSet *)primitiveInstallationImages;
-- (void)setPrimitiveInstallationImages:(NSMutableSet *)value;
+- (NSMutableSet<InstallShotImage *> *)primitiveInstallationImages;
+- (void)setPrimitiveInstallationImages:(NSMutableSet<InstallShotImage *> *)value;
 
 - (Location *)primitiveLocation;
 - (void)setPrimitiveLocation:(Location *)value;
 
 @end
+
+
+@interface ShowAttributes : NSObject
++ (NSString *)availabilityPeriod;
++ (NSString *)createdAt;
++ (NSString *)endsAt;
++ (NSString *)name;
++ (NSString *)showSlug;
++ (NSString *)slug;
++ (NSString *)sortKey;
++ (NSString *)startsAt;
++ (NSString *)status;
++ (NSString *)updatedAt;
+@end
+
+
+@interface ShowRelationships : NSObject
++ (NSString *)artists;
++ (NSString *)artworks;
++ (NSString *)cover;
++ (NSString *)documents;
++ (NSString *)installationImages;
++ (NSString *)location;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_Show.m
+++ b/Classes/Models/Generated/_Show.m
@@ -3,30 +3,6 @@
 
 #import "_Show.h"
 
-const struct ShowAttributes ShowAttributes = {
-    .availabilityPeriod = @"availabilityPeriod",
-    .createdAt = @"createdAt",
-    .endsAt = @"endsAt",
-    .name = @"name",
-    .showSlug = @"showSlug",
-    .slug = @"slug",
-    .sortKey = @"sortKey",
-    .startsAt = @"startsAt",
-    .status = @"status",
-    .updatedAt = @"updatedAt",
-};
-
-const struct ShowRelationships ShowRelationships = {
-    .artists = @"artists",
-    .artworks = @"artworks",
-    .cover = @"cover",
-    .documents = @"documents",
-    .installationImages = @"installationImages",
-    .location = @"location",
-};
-
-const struct ShowUserInfo ShowUserInfo = {};
-
 
 @implementation ShowID
 @end
@@ -34,7 +10,7 @@ const struct ShowUserInfo ShowUserInfo = {};
 
 @implementation _Show
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"Show" inManagedObjectContext:moc_];
@@ -56,57 +32,183 @@ const struct ShowUserInfo ShowUserInfo = {};
     return (ShowID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    if ([key isEqualToString:@"sortKeyValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"sortKey"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+
+    return keyPaths;
+}
 
 @dynamic availabilityPeriod;
+
 @dynamic createdAt;
+
 @dynamic endsAt;
+
 @dynamic name;
+
 @dynamic showSlug;
+
 @dynamic slug;
+
 @dynamic sortKey;
+
+- (int16_t)sortKeyValue
+{
+    NSNumber *result = [self sortKey];
+    return [result shortValue];
+}
+
+- (void)setSortKeyValue:(int16_t)value_
+{
+    [self setSortKey:@(value_)];
+}
+
+- (int16_t)primitiveSortKeyValue
+{
+    NSNumber *result = [self primitiveSortKey];
+    return [result shortValue];
+}
+
+- (void)setPrimitiveSortKeyValue:(int16_t)value_
+{
+    [self setPrimitiveSortKey:@(value_)];
+}
+
 @dynamic startsAt;
+
 @dynamic status;
+
 @dynamic updatedAt;
 
-
 @dynamic artists;
-- (NSMutableSet *)artistsSet
+
+- (NSMutableSet<Artist *> *)artistsSet
 {
     [self willAccessValueForKey:@"artists"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"artists"];
+
+    NSMutableSet<Artist *> *result = (NSMutableSet<Artist *> *)[self mutableSetValueForKey:@"artists"];
+
     [self didAccessValueForKey:@"artists"];
     return result;
 }
 
 @dynamic artworks;
-- (NSMutableSet *)artworksSet
+
+- (NSMutableSet<Artwork *> *)artworksSet
 {
     [self willAccessValueForKey:@"artworks"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"artworks"];
+
+    NSMutableSet<Artwork *> *result = (NSMutableSet<Artwork *> *)[self mutableSetValueForKey:@"artworks"];
+
     [self didAccessValueForKey:@"artworks"];
     return result;
 }
 
 @dynamic cover;
+
 @dynamic documents;
-- (NSMutableSet *)documentsSet
+
+- (NSMutableSet<Document *> *)documentsSet
 {
     [self willAccessValueForKey:@"documents"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"documents"];
+
+    NSMutableSet<Document *> *result = (NSMutableSet<Document *> *)[self mutableSetValueForKey:@"documents"];
+
     [self didAccessValueForKey:@"documents"];
     return result;
 }
 
 @dynamic installationImages;
-- (NSMutableSet *)installationImagesSet
+
+- (NSMutableSet<InstallShotImage *> *)installationImagesSet
 {
     [self willAccessValueForKey:@"installationImages"];
-    NSMutableSet *result = (NSMutableSet *)[self mutableSetValueForKey:@"installationImages"];
+
+    NSMutableSet<InstallShotImage *> *result = (NSMutableSet<InstallShotImage *> *)[self mutableSetValueForKey:@"installationImages"];
+
     [self didAccessValueForKey:@"installationImages"];
     return result;
 }
 
 @dynamic location;
 
+@end
 
+
+@implementation ShowAttributes
++ (NSString *)availabilityPeriod
+{
+    return @"availabilityPeriod";
+}
++ (NSString *)createdAt
+{
+    return @"createdAt";
+}
++ (NSString *)endsAt
+{
+    return @"endsAt";
+}
++ (NSString *)name
+{
+    return @"name";
+}
++ (NSString *)showSlug
+{
+    return @"showSlug";
+}
++ (NSString *)slug
+{
+    return @"slug";
+}
++ (NSString *)sortKey
+{
+    return @"sortKey";
+}
++ (NSString *)startsAt
+{
+    return @"startsAt";
+}
++ (NSString *)status
+{
+    return @"status";
+}
++ (NSString *)updatedAt
+{
+    return @"updatedAt";
+}
+@end
+
+
+@implementation ShowRelationships
++ (NSString *)artists
+{
+    return @"artists";
+}
++ (NSString *)artworks
+{
+    return @"artworks";
+}
++ (NSString *)cover
+{
+    return @"cover";
+}
++ (NSString *)documents
+{
+    return @"documents";
+}
++ (NSString *)installationImages
+{
+    return @"installationImages";
+}
++ (NSString *)location
+{
+    return @"location";
+}
 @end

--- a/Classes/Models/Generated/_ShowDocument.h
+++ b/Classes/Models/Generated/_ShowDocument.h
@@ -1,25 +1,30 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to ShowDocument.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "Document.h"
 
-extern const struct ShowDocumentUserInfo {
-} ShowDocumentUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 
-@interface ShowDocumentID : DocumentID {
+@interface ShowDocumentID : DocumentID
+{
 }
 @end
 
 
-@interface _ShowDocument : Document {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _ShowDocument : Document
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (ShowDocumentID *)objectID;
-
+@property (nonatomic, readonly, strong) ShowDocumentID *objectID;
 
 @end
 
@@ -27,3 +32,5 @@ extern const struct ShowDocumentUserInfo {
 @interface _ShowDocument (CoreDataGeneratedPrimitiveAccessors)
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_ShowDocument.m
+++ b/Classes/Models/Generated/_ShowDocument.m
@@ -3,8 +3,6 @@
 
 #import "_ShowDocument.h"
 
-const struct ShowDocumentUserInfo ShowDocumentUserInfo = {};
-
 
 @implementation ShowDocumentID
 @end
@@ -12,7 +10,7 @@ const struct ShowDocumentUserInfo ShowDocumentUserInfo = {};
 
 @implementation _ShowDocument
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"ShowDocument" inManagedObjectContext:moc_];
@@ -34,5 +32,11 @@ const struct ShowDocumentUserInfo ShowDocumentUserInfo = {};
     return (ShowDocumentID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    return keyPaths;
+}
 
 @end

--- a/Classes/Models/Generated/_SubscriptionPlan.h
+++ b/Classes/Models/Generated/_SubscriptionPlan.h
@@ -1,45 +1,58 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to SubscriptionPlan.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "ARManagedObject.h"
 
-extern const struct SubscriptionPlanAttributes {
-    __unsafe_unretained NSString *name;
-} SubscriptionPlanAttributes;
-
-extern const struct SubscriptionPlanRelationships {
-    __unsafe_unretained NSString *subscriptionForPartner;
-} SubscriptionPlanRelationships;
-
-extern const struct SubscriptionPlanUserInfo {
-} SubscriptionPlanUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 @class Partner;
 
 
-@interface SubscriptionPlanID : ARManagedObjectID {
+@interface SubscriptionPlanID : NSManagedObjectID
+{
 }
 @end
 
 
-@interface _SubscriptionPlan : ARManagedObject {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _SubscriptionPlan : ARManagedObject
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (SubscriptionPlanID *)objectID;
+@property (nonatomic, readonly, strong) SubscriptionPlanID *objectID;
 
-@property (nonatomic, strong) NSString *name;
-@property (nonatomic, strong) Partner *subscriptionForPartner;
+@property (nonatomic, strong, nullable) NSString *name;
 
+@property (nonatomic, strong, nullable) Partner *subscriptionForPartner;
 
 @end
 
 
 @interface _SubscriptionPlan (CoreDataGeneratedPrimitiveAccessors)
 
+- (NSString *)primitiveName;
+- (void)setPrimitiveName:(NSString *)value;
+
 - (Partner *)primitiveSubscriptionForPartner;
 - (void)setPrimitiveSubscriptionForPartner:(Partner *)value;
 
 @end
+
+
+@interface SubscriptionPlanAttributes : NSObject
++ (NSString *)name;
+@end
+
+
+@interface SubscriptionPlanRelationships : NSObject
++ (NSString *)subscriptionForPartner;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_SubscriptionPlan.m
+++ b/Classes/Models/Generated/_SubscriptionPlan.m
@@ -3,16 +3,6 @@
 
 #import "_SubscriptionPlan.h"
 
-const struct SubscriptionPlanAttributes SubscriptionPlanAttributes = {
-    .name = @"name",
-};
-
-const struct SubscriptionPlanRelationships SubscriptionPlanRelationships = {
-    .subscriptionForPartner = @"subscriptionForPartner",
-};
-
-const struct SubscriptionPlanUserInfo SubscriptionPlanUserInfo = {};
-
 
 @implementation SubscriptionPlanID
 @end
@@ -20,7 +10,7 @@ const struct SubscriptionPlanUserInfo SubscriptionPlanUserInfo = {};
 
 @implementation _SubscriptionPlan
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"SubscriptionPlan" inManagedObjectContext:moc_];
@@ -42,11 +32,31 @@ const struct SubscriptionPlanUserInfo SubscriptionPlanUserInfo = {};
     return (SubscriptionPlanID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    return keyPaths;
+}
 
 @dynamic name;
 
-
 @dynamic subscriptionForPartner;
 
+@end
 
+
+@implementation SubscriptionPlanAttributes
++ (NSString *)name
+{
+    return @"name";
+}
+@end
+
+
+@implementation SubscriptionPlanRelationships
++ (NSString *)subscriptionForPartner
+{
+    return @"subscriptionForPartner";
+}
 @end

--- a/Classes/Models/Generated/_SyncError.h
+++ b/Classes/Models/Generated/_SyncError.h
@@ -1,47 +1,64 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to SyncError.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "ARManagedObject.h"
 
-extern const struct SyncErrorAttributes {
-    __unsafe_unretained NSString *body;
-    __unsafe_unretained NSString *errorType;
-} SyncErrorAttributes;
-
-extern const struct SyncErrorRelationships {
-    __unsafe_unretained NSString *syncLog;
-} SyncErrorRelationships;
-
-extern const struct SyncErrorUserInfo {
-} SyncErrorUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 @class SyncLog;
 
 
-@interface SyncErrorID : ARManagedObjectID {
+@interface SyncErrorID : NSManagedObjectID
+{
 }
 @end
 
 
-@interface _SyncError : ARManagedObject {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _SyncError : ARManagedObject
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (SyncErrorID *)objectID;
+@property (nonatomic, readonly, strong) SyncErrorID *objectID;
 
-@property (nonatomic, strong) NSString *body;
-@property (nonatomic, strong) NSString *errorType;
-@property (nonatomic, strong) SyncLog *syncLog;
+@property (nonatomic, strong, nullable) NSString *body;
 
+@property (nonatomic, strong, nullable) NSString *errorType;
+
+@property (nonatomic, strong, nullable) SyncLog *syncLog;
 
 @end
 
 
 @interface _SyncError (CoreDataGeneratedPrimitiveAccessors)
 
+- (NSString *)primitiveBody;
+- (void)setPrimitiveBody:(NSString *)value;
+
+- (NSString *)primitiveErrorType;
+- (void)setPrimitiveErrorType:(NSString *)value;
+
 - (SyncLog *)primitiveSyncLog;
 - (void)setPrimitiveSyncLog:(SyncLog *)value;
 
 @end
+
+
+@interface SyncErrorAttributes : NSObject
++ (NSString *)body;
++ (NSString *)errorType;
+@end
+
+
+@interface SyncErrorRelationships : NSObject
++ (NSString *)syncLog;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_SyncError.m
+++ b/Classes/Models/Generated/_SyncError.m
@@ -3,17 +3,6 @@
 
 #import "_SyncError.h"
 
-const struct SyncErrorAttributes SyncErrorAttributes = {
-    .body = @"body",
-    .errorType = @"errorType",
-};
-
-const struct SyncErrorRelationships SyncErrorRelationships = {
-    .syncLog = @"syncLog",
-};
-
-const struct SyncErrorUserInfo SyncErrorUserInfo = {};
-
 
 @implementation SyncErrorID
 @end
@@ -21,7 +10,7 @@ const struct SyncErrorUserInfo SyncErrorUserInfo = {};
 
 @implementation _SyncError
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"SyncError" inManagedObjectContext:moc_];
@@ -43,12 +32,37 @@ const struct SyncErrorUserInfo SyncErrorUserInfo = {};
     return (SyncErrorID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    return keyPaths;
+}
 
 @dynamic body;
-@dynamic errorType;
 
+@dynamic errorType;
 
 @dynamic syncLog;
 
+@end
 
+
+@implementation SyncErrorAttributes
++ (NSString *)body
+{
+    return @"body";
+}
++ (NSString *)errorType
+{
+    return @"errorType";
+}
+@end
+
+
+@implementation SyncErrorRelationships
++ (NSString *)syncLog
+{
+    return @"syncLog";
+}
 @end

--- a/Classes/Models/Generated/_SyncLog.h
+++ b/Classes/Models/Generated/_SyncLog.h
@@ -1,57 +1,136 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to SyncLog.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "ARManagedObject.h"
 
-extern const struct SyncLogAttributes {
-    __unsafe_unretained NSString *albumsDelta;
-    __unsafe_unretained NSString *artworkDelta;
-    __unsafe_unretained NSString *dateStarted;
-    __unsafe_unretained NSString *estimatedDownload;
-    __unsafe_unretained NSString *showDelta;
-    __unsafe_unretained NSString *timeToCompletion;
-    __unsafe_unretained NSString *totalDownloaded;
-} SyncLogAttributes;
-
-extern const struct SyncLogRelationships {
-    __unsafe_unretained NSString *syncErrors;
-} SyncLogRelationships;
-
-extern const struct SyncLogUserInfo {
-} SyncLogUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 @class SyncError;
 
 
-@interface SyncLogID : ARManagedObjectID {
+@interface SyncLogID : NSManagedObjectID
+{
 }
 @end
 
 
-@interface _SyncLog : ARManagedObject {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _SyncLog : ARManagedObject
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (SyncLogID *)objectID;
+@property (nonatomic, readonly, strong) SyncLogID *objectID;
 
-@property (nonatomic, strong) NSNumber *albumsDelta;
-@property (nonatomic, strong) NSNumber *artworkDelta;
-@property (nonatomic, strong) NSDate *dateStarted;
-@property (nonatomic, strong) NSNumber *estimatedDownload;
-@property (nonatomic, strong) NSNumber *showDelta;
-@property (nonatomic, strong) NSNumber *timeToCompletion;
-@property (nonatomic, strong) NSNumber *totalDownloaded;
-@property (nonatomic, strong) SyncError *syncErrors;
+@property (nonatomic, strong, nullable) NSNumber *albumsDelta;
 
+@property (atomic) int32_t albumsDeltaValue;
+- (int32_t)albumsDeltaValue;
+- (void)setAlbumsDeltaValue:(int32_t)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *artworkDelta;
+
+@property (atomic) int32_t artworkDeltaValue;
+- (int32_t)artworkDeltaValue;
+- (void)setArtworkDeltaValue:(int32_t)value_;
+
+@property (nonatomic, strong, nullable) NSDate *dateStarted;
+
+@property (nonatomic, strong, nullable) NSNumber *estimatedDownload;
+
+@property (atomic) int64_t estimatedDownloadValue;
+- (int64_t)estimatedDownloadValue;
+- (void)setEstimatedDownloadValue:(int64_t)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *showDelta;
+
+@property (atomic) int32_t showDeltaValue;
+- (int32_t)showDeltaValue;
+- (void)setShowDeltaValue:(int32_t)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *timeToCompletion;
+
+@property (atomic) int64_t timeToCompletionValue;
+- (int64_t)timeToCompletionValue;
+- (void)setTimeToCompletionValue:(int64_t)value_;
+
+@property (nonatomic, strong, nullable) NSNumber *totalDownloaded;
+
+@property (atomic) int64_t totalDownloadedValue;
+- (int64_t)totalDownloadedValue;
+- (void)setTotalDownloadedValue:(int64_t)value_;
+
+@property (nonatomic, strong, nullable) SyncError *syncErrors;
 
 @end
 
 
 @interface _SyncLog (CoreDataGeneratedPrimitiveAccessors)
 
+- (NSNumber *)primitiveAlbumsDelta;
+- (void)setPrimitiveAlbumsDelta:(NSNumber *)value;
+
+- (int32_t)primitiveAlbumsDeltaValue;
+- (void)setPrimitiveAlbumsDeltaValue:(int32_t)value_;
+
+- (NSNumber *)primitiveArtworkDelta;
+- (void)setPrimitiveArtworkDelta:(NSNumber *)value;
+
+- (int32_t)primitiveArtworkDeltaValue;
+- (void)setPrimitiveArtworkDeltaValue:(int32_t)value_;
+
+- (NSDate *)primitiveDateStarted;
+- (void)setPrimitiveDateStarted:(NSDate *)value;
+
+- (NSNumber *)primitiveEstimatedDownload;
+- (void)setPrimitiveEstimatedDownload:(NSNumber *)value;
+
+- (int64_t)primitiveEstimatedDownloadValue;
+- (void)setPrimitiveEstimatedDownloadValue:(int64_t)value_;
+
+- (NSNumber *)primitiveShowDelta;
+- (void)setPrimitiveShowDelta:(NSNumber *)value;
+
+- (int32_t)primitiveShowDeltaValue;
+- (void)setPrimitiveShowDeltaValue:(int32_t)value_;
+
+- (NSNumber *)primitiveTimeToCompletion;
+- (void)setPrimitiveTimeToCompletion:(NSNumber *)value;
+
+- (int64_t)primitiveTimeToCompletionValue;
+- (void)setPrimitiveTimeToCompletionValue:(int64_t)value_;
+
+- (NSNumber *)primitiveTotalDownloaded;
+- (void)setPrimitiveTotalDownloaded:(NSNumber *)value;
+
+- (int64_t)primitiveTotalDownloadedValue;
+- (void)setPrimitiveTotalDownloadedValue:(int64_t)value_;
+
 - (SyncError *)primitiveSyncErrors;
 - (void)setPrimitiveSyncErrors:(SyncError *)value;
 
 @end
+
+
+@interface SyncLogAttributes : NSObject
++ (NSString *)albumsDelta;
++ (NSString *)artworkDelta;
++ (NSString *)dateStarted;
++ (NSString *)estimatedDownload;
++ (NSString *)showDelta;
++ (NSString *)timeToCompletion;
++ (NSString *)totalDownloaded;
+@end
+
+
+@interface SyncLogRelationships : NSObject
++ (NSString *)syncErrors;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_SyncLog.m
+++ b/Classes/Models/Generated/_SyncLog.m
@@ -3,22 +3,6 @@
 
 #import "_SyncLog.h"
 
-const struct SyncLogAttributes SyncLogAttributes = {
-    .albumsDelta = @"albumsDelta",
-    .artworkDelta = @"artworkDelta",
-    .dateStarted = @"dateStarted",
-    .estimatedDownload = @"estimatedDownload",
-    .showDelta = @"showDelta",
-    .timeToCompletion = @"timeToCompletion",
-    .totalDownloaded = @"totalDownloaded",
-};
-
-const struct SyncLogRelationships SyncLogRelationships = {
-    .syncErrors = @"syncErrors",
-};
-
-const struct SyncLogUserInfo SyncLogUserInfo = {};
-
 
 @implementation SyncLogID
 @end
@@ -26,7 +10,7 @@ const struct SyncLogUserInfo SyncLogUserInfo = {};
 
 @implementation _SyncLog
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"SyncLog" inManagedObjectContext:moc_];
@@ -48,17 +32,230 @@ const struct SyncLogUserInfo SyncLogUserInfo = {};
     return (SyncLogID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    if ([key isEqualToString:@"albumsDeltaValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"albumsDelta"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"artworkDeltaValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"artworkDelta"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"estimatedDownloadValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"estimatedDownload"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"showDeltaValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"showDelta"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"timeToCompletionValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"timeToCompletion"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+    if ([key isEqualToString:@"totalDownloadedValue"]) {
+        NSSet *affectingKey = [NSSet setWithObject:@"totalDownloaded"];
+        keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+        return keyPaths;
+    }
+
+    return keyPaths;
+}
 
 @dynamic albumsDelta;
+
+- (int32_t)albumsDeltaValue
+{
+    NSNumber *result = [self albumsDelta];
+    return [result intValue];
+}
+
+- (void)setAlbumsDeltaValue:(int32_t)value_
+{
+    [self setAlbumsDelta:@(value_)];
+}
+
+- (int32_t)primitiveAlbumsDeltaValue
+{
+    NSNumber *result = [self primitiveAlbumsDelta];
+    return [result intValue];
+}
+
+- (void)setPrimitiveAlbumsDeltaValue:(int32_t)value_
+{
+    [self setPrimitiveAlbumsDelta:@(value_)];
+}
+
 @dynamic artworkDelta;
+
+- (int32_t)artworkDeltaValue
+{
+    NSNumber *result = [self artworkDelta];
+    return [result intValue];
+}
+
+- (void)setArtworkDeltaValue:(int32_t)value_
+{
+    [self setArtworkDelta:@(value_)];
+}
+
+- (int32_t)primitiveArtworkDeltaValue
+{
+    NSNumber *result = [self primitiveArtworkDelta];
+    return [result intValue];
+}
+
+- (void)setPrimitiveArtworkDeltaValue:(int32_t)value_
+{
+    [self setPrimitiveArtworkDelta:@(value_)];
+}
+
 @dynamic dateStarted;
+
 @dynamic estimatedDownload;
+
+- (int64_t)estimatedDownloadValue
+{
+    NSNumber *result = [self estimatedDownload];
+    return [result longLongValue];
+}
+
+- (void)setEstimatedDownloadValue:(int64_t)value_
+{
+    [self setEstimatedDownload:@(value_)];
+}
+
+- (int64_t)primitiveEstimatedDownloadValue
+{
+    NSNumber *result = [self primitiveEstimatedDownload];
+    return [result longLongValue];
+}
+
+- (void)setPrimitiveEstimatedDownloadValue:(int64_t)value_
+{
+    [self setPrimitiveEstimatedDownload:@(value_)];
+}
+
 @dynamic showDelta;
+
+- (int32_t)showDeltaValue
+{
+    NSNumber *result = [self showDelta];
+    return [result intValue];
+}
+
+- (void)setShowDeltaValue:(int32_t)value_
+{
+    [self setShowDelta:@(value_)];
+}
+
+- (int32_t)primitiveShowDeltaValue
+{
+    NSNumber *result = [self primitiveShowDelta];
+    return [result intValue];
+}
+
+- (void)setPrimitiveShowDeltaValue:(int32_t)value_
+{
+    [self setPrimitiveShowDelta:@(value_)];
+}
+
 @dynamic timeToCompletion;
+
+- (int64_t)timeToCompletionValue
+{
+    NSNumber *result = [self timeToCompletion];
+    return [result longLongValue];
+}
+
+- (void)setTimeToCompletionValue:(int64_t)value_
+{
+    [self setTimeToCompletion:@(value_)];
+}
+
+- (int64_t)primitiveTimeToCompletionValue
+{
+    NSNumber *result = [self primitiveTimeToCompletion];
+    return [result longLongValue];
+}
+
+- (void)setPrimitiveTimeToCompletionValue:(int64_t)value_
+{
+    [self setPrimitiveTimeToCompletion:@(value_)];
+}
+
 @dynamic totalDownloaded;
 
+- (int64_t)totalDownloadedValue
+{
+    NSNumber *result = [self totalDownloaded];
+    return [result longLongValue];
+}
+
+- (void)setTotalDownloadedValue:(int64_t)value_
+{
+    [self setTotalDownloaded:@(value_)];
+}
+
+- (int64_t)primitiveTotalDownloadedValue
+{
+    NSNumber *result = [self primitiveTotalDownloaded];
+    return [result longLongValue];
+}
+
+- (void)setPrimitiveTotalDownloadedValue:(int64_t)value_
+{
+    [self setPrimitiveTotalDownloaded:@(value_)];
+}
 
 @dynamic syncErrors;
 
+@end
 
+
+@implementation SyncLogAttributes
++ (NSString *)albumsDelta
+{
+    return @"albumsDelta";
+}
++ (NSString *)artworkDelta
+{
+    return @"artworkDelta";
+}
++ (NSString *)dateStarted
+{
+    return @"dateStarted";
+}
++ (NSString *)estimatedDownload
+{
+    return @"estimatedDownload";
+}
++ (NSString *)showDelta
+{
+    return @"showDelta";
+}
++ (NSString *)timeToCompletion
+{
+    return @"timeToCompletion";
+}
++ (NSString *)totalDownloaded
+{
+    return @"totalDownloaded";
+}
+@end
+
+
+@implementation SyncLogRelationships
++ (NSString *)syncErrors
+{
+    return @"syncErrors";
+}
 @end

--- a/Classes/Models/Generated/_User.h
+++ b/Classes/Models/Generated/_User.h
@@ -1,51 +1,73 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to User.h instead.
 
+#if __has_feature(modules)
+@import Foundation;
+@import CoreData;
+#else
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#endif
+
 #import "ARManagedObject.h"
 
-extern const struct UserAttributes {
-    __unsafe_unretained NSString *email;
-    __unsafe_unretained NSString *name;
-    __unsafe_unretained NSString *slug;
-    __unsafe_unretained NSString *type;
-} UserAttributes;
-
-extern const struct UserRelationships {
-    __unsafe_unretained NSString *adminForPartner;
-} UserRelationships;
-
-extern const struct UserUserInfo {
-} UserUserInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 @class Partner;
 
 
-@interface UserID : ARManagedObjectID {
+@interface UserID : NSManagedObjectID
+{
 }
 @end
 
 
-@interface _User : ARManagedObject {
-}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
+@interface _User : ARManagedObject
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString *)entityName;
 + (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)moc_;
-- (UserID *)objectID;
+@property (nonatomic, readonly, strong) UserID *objectID;
 
-@property (nonatomic, strong) NSString *email;
-@property (nonatomic, strong) NSString *name;
-@property (nonatomic, strong) NSString *slug;
-@property (nonatomic, strong) NSString *type;
-@property (nonatomic, strong) Partner *adminForPartner;
+@property (nonatomic, strong, nullable) NSString *email;
 
+@property (nonatomic, strong, nullable) NSString *name;
+
+@property (nonatomic, strong, nullable) NSString *slug;
+
+@property (nonatomic, strong, nullable) NSString *type;
+
+@property (nonatomic, strong, nullable) Partner *adminForPartner;
 
 @end
 
 
 @interface _User (CoreDataGeneratedPrimitiveAccessors)
 
+- (NSString *)primitiveEmail;
+- (void)setPrimitiveEmail:(NSString *)value;
+
+- (NSString *)primitiveName;
+- (void)setPrimitiveName:(NSString *)value;
+
+- (NSString *)primitiveSlug;
+- (void)setPrimitiveSlug:(NSString *)value;
+
 - (Partner *)primitiveAdminForPartner;
 - (void)setPrimitiveAdminForPartner:(Partner *)value;
 
 @end
+
+
+@interface UserAttributes : NSObject
++ (NSString *)email;
++ (NSString *)name;
++ (NSString *)slug;
++ (NSString *)type;
+@end
+
+
+@interface UserRelationships : NSObject
++ (NSString *)adminForPartner;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Models/Generated/_User.m
+++ b/Classes/Models/Generated/_User.m
@@ -3,19 +3,6 @@
 
 #import "_User.h"
 
-const struct UserAttributes UserAttributes = {
-    .email = @"email",
-    .name = @"name",
-    .slug = @"slug",
-    .type = @"type",
-};
-
-const struct UserRelationships UserRelationships = {
-    .adminForPartner = @"adminForPartner",
-};
-
-const struct UserUserInfo UserUserInfo = {};
-
 
 @implementation UserID
 @end
@@ -23,7 +10,7 @@ const struct UserUserInfo UserUserInfo = {};
 
 @implementation _User
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_
 {
     NSParameterAssert(moc_);
     return [NSEntityDescription insertNewObjectForEntityForName:@"User" inManagedObjectContext:moc_];
@@ -45,14 +32,49 @@ const struct UserUserInfo UserUserInfo = {};
     return (UserID *)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+    NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+
+    return keyPaths;
+}
 
 @dynamic email;
-@dynamic name;
-@dynamic slug;
-@dynamic type;
 
+@dynamic name;
+
+@dynamic slug;
+
+@dynamic type;
 
 @dynamic adminForPartner;
 
+@end
 
+
+@implementation UserAttributes
++ (NSString *)email
+{
+    return @"email";
+}
++ (NSString *)name
+{
+    return @"name";
+}
++ (NSString *)slug
+{
+    return @"slug";
+}
++ (NSString *)type
+{
+    return @"type";
+}
+@end
+
+
+@implementation UserRelationships
++ (NSString *)adminForPartner
+{
+    return @"adminForPartner";
+}
 @end

--- a/Classes/Models/Show.m
+++ b/Classes/Models/Show.m
@@ -48,7 +48,9 @@ static NSArray *sorts;
 {
     self.artists = nil;
     for (Artwork *artwork in self.artworks) {
-        [self addArtistsObject:artwork.artist];
+        for (Artist *artist in artwork.artists) {
+            [self addArtistsObject:artist];
+        }
     }
     [self updateName];
 }

--- a/Classes/Sync/ARSyncDeleter.m
+++ b/Classes/Sync/ARSyncDeleter.m
@@ -82,12 +82,11 @@
 
     ARSyncLog(@"Removing %@ objects", @(objects.count));
 
-    @synchronized(self)
-    {
+    [self.context performBlock:^{
         for (NSManagedObject *object in objects) {
             [context deleteObject:object];
         }
-    }
+    }];
 }
 
 - (NSSet *)markedObjects

--- a/Classes/Sync/Admin UI/ARSyncAdminViewController.xib
+++ b/Classes/Sync/Admin UI/ARSyncAdminViewController.xib
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="7702" systemVersion="14E17e" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="10117" systemVersion="15G24b" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ARSyncAdminViewController">
             <connections>
+                <outlet property="activeTextView" destination="0iy-6y-AJL" id="899-YJ-Dax"/>
                 <outlet property="adminTextView" destination="pfa-hI-PuR" id="WU4-Wd-aZk"/>
                 <outlet property="operationCountLabel" destination="n32-TC-Z46" id="FiH-gK-UmU"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
@@ -18,7 +19,7 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" editable="NO" selectable="NO" id="pfa-hI-PuR">
-                    <rect key="frame" x="29" y="70" width="711" height="875"/>
+                    <rect key="frame" x="29" y="70" width="298" height="875"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                     <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
@@ -49,14 +50,17 @@
                         <action selector="exitButtonTapped:" destination="-1" eventType="touchUpInside" id="SgG-WZ-Xge"/>
                     </connections>
                 </button>
+                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" editable="NO" selectable="NO" id="0iy-6y-AJL">
+                    <rect key="frame" x="450" y="70" width="298" height="875"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                    <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                    <fontDescription key="fontDescription" name="Courier" family="Courier" pointSize="14"/>
+                    <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                </textView>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <nil key="simulatedStatusBarMetrics"/>
         </view>
     </objects>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination"/>
-    </simulatedMetricsContainer>
 </document>

--- a/Classes/Sync/Artworks/ARArtworkDownloader.m
+++ b/Classes/Sync/Artworks/ARArtworkDownloader.m
@@ -57,7 +57,9 @@
             Artwork *artwork = objects.firstObject;
 
             [self.deleter unmarkObjectForDeletion:artwork];
-            [self.deleter unmarkObjectForDeletion:artwork.artist];
+            for (id artist in artwork.artists) {
+                [self.deleter unmarkObjectForDeletion:artist];
+            }
 
             for (id image in artwork.images) {
                 [self.deleter unmarkObjectForDeletion:image];
@@ -69,7 +71,7 @@
             if ([object isEqual:self.artworkIDs.lastObject]) {
                 [[NSNotificationCenter defaultCenter] postNotificationName:ARAllArtworksDownloadedNotification object:nil userInfo:nil];
             }
-            
+
             continuation(artwork, nil);
         }];
 

--- a/Classes/Util/App/ARSwitchBoard.m
+++ b/Classes/Util/App/ARSwitchBoard.m
@@ -195,7 +195,7 @@
         [ARTopViewController sharedInstance].displayMode = mode;
         [navController pushViewController:controller animated:NO];
 
-        [UIView animateIf:animates duration:ARAnimationQuickDuration :^{
+        [UIView animateIf:animates duration:ARAnimationQuickDuration:^{
             [navController view].alpha = 1;
         }];
     }];
@@ -231,7 +231,7 @@
     // then put a ArtistVC with the artwork's artist in it
     // then put in the ArtworkdetailVC for the artwork at the right index
 
-    ARArtistViewController *artistController = [[ARArtistViewController alloc] initWithArtist:artwork.artist];
+    ARArtistViewController *artistController = [[ARArtistViewController alloc] initWithArtist:artwork.artists.anyObject];
 
     NSFetchRequest *fetchRequest = [artwork.artist artworksFetchRequestSortedBy:ARArtworksSortOrderDefault];
     NSFetchedResultsController *controller = [self fetchedResultsControllerForArtworksRequest:fetchRequest];

--- a/Classes/Util/App/ARSwitchBoard.m
+++ b/Classes/Util/App/ARSwitchBoard.m
@@ -237,7 +237,7 @@
     NSFetchedResultsController *controller = [self fetchedResultsControllerForArtworksRequest:fetchRequest];
 
     NSInteger index = [controller indexPathForObject:artwork].row;
-    ARArtworkSetViewController *artworkController = [[ARArtworkSetViewController alloc] initWithArtworks:controller atIndex:index representedObject:artwork.artist defaults:[NSUserDefaults standardUserDefaults]];
+    ARArtworkSetViewController *artworkController = [[ARArtworkSetViewController alloc] initWithArtworks:controller atIndex:index representedObject:artwork.artists.anyObject defaults:[NSUserDefaults standardUserDefaults]];
 
     UINavigationController *navController = [self navigationController];
     [UIView animateWithDuration:ARAnimationQuickDuration animations:^{

--- a/Classes/Util/App/ARSwitchBoard.m
+++ b/Classes/Util/App/ARSwitchBoard.m
@@ -233,7 +233,7 @@
 
     ARArtistViewController *artistController = [[ARArtistViewController alloc] initWithArtist:artwork.artists.anyObject];
 
-    NSFetchRequest *fetchRequest = [artwork.artist artworksFetchRequestSortedBy:ARArtworksSortOrderDefault];
+    NSFetchRequest *fetchRequest = [artistController.representedObject artworksFetchRequestSortedBy:ARArtworksSortOrderDefault];
     NSFetchedResultsController *controller = [self fetchedResultsControllerForArtworksRequest:fetchRequest];
 
     NSInteger index = [controller indexPathForObject:artwork].row;

--- a/Classes/Util/Debugging/ARAnalyticsHelper.m
+++ b/Classes/Util/Debugging/ARAnalyticsHelper.m
@@ -3,6 +3,7 @@
 #import <ARAnalytics/ARAnalytics.h>
 #import <Keys/FolioKeys.h>
 #import <Analytics/SEGAnalytics.h>
+#import <HockeySDK-Source/HockeySDK.h>
 
 #import "ARAnalyticsHelper.h"
 #import "ARIntercomProvider.h"
@@ -32,6 +33,12 @@ static NSString *currentUserEmail;
     BOOL isBeta = [bundleIdentifier hasPrefix:@".beta"];
 
     NSString *segment = isAppStore ? [keys segmentProduction] : isBeta ? [keys segmentBeta] : [keys segmentDev];
+
+#if DEBUG
+    BITHockeyManager *hockey = [BITHockeyManager sharedHockeyManager];
+    hockey.disableUpdateManager = YES;
+    hockey.disableCrashManager = YES;
+#endif
 
     [ARAnalytics setupWithAnalytics:@{
         ARHockeyAppBetaID : [keys hockeyAppBetaID],

--- a/Classes/Util/Migrations/ARMigrationController.m
+++ b/Classes/Util/Migrations/ARMigrationController.m
@@ -12,12 +12,16 @@
     NSString *oldMigrationVersion = [defaults stringForKey:ARAppSyncVersion];
     CGFloat pastVersion = [oldMigrationVersion floatValue];
 
-    if (pastVersion && pastVersion < 1.39) {
-        ARSyncLog(@"Migrating!");
+    /// Converts pre 2.5.1 versions of Folio to support multiple artists
+    BOOL shouldSwitchArtistToArtists = [defaults boolForKey:@"ARHasSwitchedArtistToArtists"] == NO;
+    if (shouldSwitchArtistToArtists) {
+        // Migrate any singular artist into artists
+        for (Artwork *artwork in [Artwork findAllInContext:context]) {
+            artwork.artists = [NSSet setWithObject:artwork.artist];
+        }
 
-        // perform migration steps (or just have users re-install now the sync is faster
+        [defaults setBool:YES forKey:@"ARHasSwitchedArtistToArtists"];
     }
-
 
     // I changed a BOOL which was incorrectly being set to YES all the time, now
     // we have a migration to switch them all to NO, and the next sync will deal with

--- a/Classes/Util/Migrations/ARMigrationController.m
+++ b/Classes/Util/Migrations/ARMigrationController.m
@@ -9,8 +9,8 @@
     [self moveCoreDataStackIfNeeded];
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSString *oldMigrationVersion = [defaults stringForKey:ARAppSyncVersion];
-    CGFloat pastVersion = [oldMigrationVersion floatValue];
+    //    NSString *oldMigrationVersion = [defaults stringForKey:ARAppSyncVersion];
+    //    CGFloat pastVersion = [oldMigrationVersion floatValue];
 
     /// Converts pre 2.5.1 versions of Folio to support multiple artists
     BOOL shouldSwitchArtistToArtists = [defaults boolForKey:@"ARHasSwitchedArtistToArtists"] == NO;

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ storyboard_ids:
 deploy_if_beta_branch:
 	if [ "$(LOCAL_BRANCH)" == "beta" ]; then make install_fastlane; fastlane beta; fi
 
-setup_fastlane:
+install_fastlane:
 	gem install cocoapods fastlane pilot gym deliver
 
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,10 @@ test:
 mogenerate:
 	@printf 'What is the new Core Data version? '; \
 		read CORE_DATA_VERSION; \
-		mogenerator -m "Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v$$CORE_DATA_VERSION.xcdatamodel" --base-class ARManagedObject --template-path config/mogenerator/artsy --machine-dir Classes/Models/Generated --human-dir /tmp --template-var arc=true
+		mogenerator -m "Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v$$CORE_DATA_VERSION.xcdatamodel" --base-class ARManagedObject --machine-dir Classes/Models/Generated --human-dir /tmp --template-var arc=true
+		for file in Classes/Models/Generated/*; do  \
+			./config/spacecommander/format-objc-file.sh $$file; \
+		done
 
 storyboard_ids:
 	bundle exec sbconstants Classes/Util/App/ARStoryboardIdentifiers.h

--- a/Resources/CoreData/ArtsyPartner.xcdatamodeld/.xccurrentversion
+++ b/Resources/CoreData/ArtsyPartner.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>ArtsyFolio v2.5.xcdatamodel</string>
+	<string>ArtsyFolio v2.5.1.xcdatamodel</string>
 </dict>
 </plist>

--- a/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v1.4.xcdatamodel/contents
+++ b/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v1.4.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model name="" userDefinedModelVersionIdentifier="1" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1811" systemVersion="12C60" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="1.4" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Automatic">
     <entity name="Album" representedClassName="Album" elementID="Collection">
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="editable" attributeType="Boolean" defaultValueString="YES" syncable="YES"/>

--- a/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v1.5.xcdatamodel/contents
+++ b/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v1.5.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model name="" userDefinedModelVersionIdentifier="1" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="2061" systemVersion="12D78" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="1.5" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Automatic">
     <entity name="Album" representedClassName="Album" elementID="Collection">
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="editable" attributeType="Boolean" defaultValueString="YES" syncable="YES"/>

--- a/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.0.xcdatamodel/contents
+++ b/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.0.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="1" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6738" systemVersion="14C81f" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="2.0" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Automatic">
     <entity name="Album" representedClassName="Album" elementID="Collection">
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="editable" optional="YES" attributeType="Boolean" defaultValueString="YES" syncable="YES"/>
@@ -291,12 +291,12 @@
         <element name="Location" positionX="0" positionY="0" width="128" height="195"/>
         <element name="Note" positionX="0" positionY="0" width="128" height="105"/>
         <element name="Partner" positionX="0" positionY="0" width="128" height="478"/>
+        <element name="PartnerOption" positionX="18" positionY="153" width="128" height="88"/>
         <element name="Show" positionX="0" positionY="0" width="128" height="285"/>
         <element name="ShowDocument" positionX="0" positionY="0" width="128" height="45"/>
+        <element name="SubscriptionPlan" positionX="27" positionY="162" width="128" height="73"/>
         <element name="SyncError" positionX="9" positionY="153" width="128" height="88"/>
         <element name="SyncLog" positionX="9" positionY="153" width="128" height="163"/>
         <element name="User" positionX="0" positionY="0" width="128" height="120"/>
-        <element name="PartnerOption" positionX="18" positionY="153" width="128" height="88"/>
-        <element name="SubscriptionPlan" positionX="27" positionY="162" width="128" height="73"/>
     </elements>
 </model>

--- a/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.1.xcdatamodel/contents
+++ b/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.1.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="1" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6751" systemVersion="14D105g" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="2.1" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Automatic">
     <entity name="Album" representedClassName="Album" elementID="Collection">
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="editable" optional="YES" attributeType="Boolean" defaultValueString="YES" syncable="YES"/>
@@ -292,6 +292,7 @@
         <element name="Artwork" positionX="0" positionY="0" width="128" height="598"/>
         <element name="Document" positionX="0" positionY="0" width="128" height="210"/>
         <element name="Image" positionX="0" positionY="0" width="128" height="360"/>
+        <element name="InstallShotImage" positionX="18" positionY="153" width="128" height="73"/>
         <element name="LocalImage" positionX="18" positionY="162" width="128" height="45"/>
         <element name="Location" positionX="0" positionY="0" width="128" height="208"/>
         <element name="Note" positionX="0" positionY="0" width="128" height="105"/>
@@ -303,6 +304,5 @@
         <element name="SyncError" positionX="9" positionY="153" width="128" height="88"/>
         <element name="SyncLog" positionX="9" positionY="153" width="128" height="163"/>
         <element name="User" positionX="0" positionY="0" width="128" height="120"/>
-        <element name="InstallShotImage" positionX="18" positionY="153" width="128" height="73"/>
     </elements>
 </model>

--- a/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.2.xcdatamodel/contents
+++ b/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.2.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="1" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="7549" systemVersion="14E11f" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="2.2" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Automatic">
     <entity name="Album" representedClassName="Album" elementID="Collection">
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="editable" optional="YES" attributeType="Boolean" defaultValueString="YES" syncable="YES"/>

--- a/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.3.xcdatamodel/contents
+++ b/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.3.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="1" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="7701" systemVersion="14D131" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="2.3" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Automatic">
     <entity name="Album" representedClassName="Album" elementID="Collection">
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="editable" optional="YES" attributeType="Boolean" defaultValueString="YES" syncable="YES"/>

--- a/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.4.xcdatamodel/contents
+++ b/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.4.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="1" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="7701" systemVersion="14D131" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="2.4" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Automatic">
     <entity name="Album" representedClassName="Album" elementID="Collection">
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="editable" optional="YES" attributeType="Boolean" defaultValueString="YES" syncable="YES"/>

--- a/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.5.1.xcdatamodel/contents
+++ b/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.5.1.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="1.7" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Automatic">
+<model userDefinedModelVersionIdentifier="2.5.1" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Automatic">
     <entity name="Album" representedClassName="Album" elementID="Collection">
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="editable" optional="YES" attributeType="Boolean" defaultValueString="YES" syncable="YES"/>
@@ -67,9 +67,11 @@
     <entity name="ArtistDocument" representedClassName="ArtistDocument" parentEntity="Document" syncable="YES"/>
     <entity name="Artwork" representedClassName="Artwork">
         <attribute name="availability" optional="YES" attributeType="String" defaultValueString="not for sale" syncable="YES"/>
+        <attribute name="backendPrice" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="category" optional="YES" attributeType="String" indexed="YES">
             <userInfo/>
         </attribute>
+        <attribute name="confidentialNotes" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="date" optional="YES" attributeType="String">
             <userInfo/>
@@ -125,11 +127,14 @@
         <relationship name="artist" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="artworks" inverseEntity="Artist">
             <userInfo/>
         </relationship>
+        <relationship name="artists" optional="YES" toMany="YES" deletionRule="No Action" destinationEntity="Artist" syncable="YES"/>
         <relationship name="collections" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Album" inverseName="artworks" inverseEntity="Album">
             <userInfo/>
         </relationship>
+        <relationship name="editionSets" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="EditionSet" inverseName="artwork" inverseEntity="EditionSet" syncable="YES"/>
         <relationship name="images" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Image" inverseName="artwork" inverseEntity="Image" syncable="YES"/>
         <relationship name="installShotsFeaturingArtwork" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Image" inverseName="artworksInImage" inverseEntity="Image" syncable="YES"/>
+        <relationship name="locations" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Location" inverseName="artworks" inverseEntity="Location" syncable="YES"/>
         <relationship name="mainImage" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Image" inverseName="mainImageForArtwork" inverseEntity="Image" syncable="YES"/>
         <relationship name="notes" optional="YES" minCount="1" maxCount="1" deletionRule="Cascade" destinationEntity="Note" inverseName="artwork" inverseEntity="Note" syncable="YES"/>
         <relationship name="partner" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Partner" inverseName="artworks" inverseEntity="Partner">
@@ -144,11 +149,33 @@
         <attribute name="humanReadableSize" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="size" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="slug" attributeType="String" defaultValueString="unknown-document" syncable="YES"/>
+        <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="version" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
         <relationship name="album" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Album" inverseName="documents" inverseEntity="Album" syncable="YES"/>
         <relationship name="artist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="documents" inverseEntity="Artist" syncable="YES"/>
         <relationship name="show" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Show" inverseName="documents" inverseEntity="Show" syncable="YES"/>
+    </entity>
+    <entity name="EditionSet" representedClassName="EditionSet" syncable="YES">
+        <attribute name="artistProofs" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="availability" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="availableEditions" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="backendPrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="depth" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="diameter" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="dimensionsCM" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dimensionsInches" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="displayPrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="duration" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="editions" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="editionSize" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="height" optional="YES" attributeType="Decimal" defaultValueString="0" syncable="YES"/>
+        <attribute name="isAvailableForSale" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="isPriceHidden" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="prototypes" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="width" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <relationship name="artwork" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artwork" inverseName="editionSets" inverseEntity="Artwork" syncable="YES"/>
     </entity>
     <entity name="Image" representedClassName="Image" syncable="YES">
         <attribute name="aspectRatio" optional="YES" attributeType="Float" defaultValueString="0.0" syncable="YES"/>
@@ -172,8 +199,12 @@
         <relationship name="coverForArtist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="cover" inverseEntity="Artist" syncable="YES"/>
         <relationship name="coverForShow" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Show" inverseName="cover" inverseEntity="Show" syncable="YES"/>
         <relationship name="mainImageForArtwork" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Artwork" inverseName="mainImage" inverseEntity="Artwork" syncable="YES"/>
+    </entity>
+    <entity name="InstallShotImage" representedClassName="InstallShotImage" parentEntity="Image" syncable="YES">
+        <attribute name="caption" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="showWithImageInInstallation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Show" inverseName="installationImages" inverseEntity="Show" syncable="YES"/>
     </entity>
+    <entity name="LocalImage" representedClassName="LocalImage" parentEntity="Image" syncable="YES"/>
     <entity name="Location" representedClassName="Location" syncable="YES">
         <attribute name="address" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="addressSecond" optional="YES" attributeType="String" syncable="YES"/>
@@ -184,6 +215,7 @@
         <attribute name="postalCode" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="slug" attributeType="String" defaultValueString="unknown-slug" syncable="YES"/>
         <attribute name="state" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="locations" inverseEntity="Artwork" syncable="YES"/>
         <relationship name="shows" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Show" inverseName="location" inverseEntity="Show" syncable="YES"/>
     </entity>
     <entity name="Note" representedClassName="Note" syncable="YES">
@@ -193,30 +225,52 @@
         <relationship name="artwork" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Artwork" inverseName="notes" inverseEntity="Artwork" syncable="YES"/>
     </entity>
     <entity name="Partner" representedClassName="Partner">
+        <attribute name="active" optional="YES" attributeType="Boolean" syncable="YES"/>
         <attribute name="artistDocumentsCount" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="artistsCount" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="artworksCount" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="contractType" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="defaultProfileID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="defaultProfilePublic" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="directlyContactable" optional="YES" attributeType="Boolean" syncable="YES"/>
         <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="foundingPartner" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="hasDefaultProfile" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="hasFullProfile" optional="YES" attributeType="Boolean" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" indexed="YES">
             <userInfo/>
         </attribute>
+        <attribute name="partnerID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="partnerLimitedAccess" optional="YES" attributeType="Boolean" syncable="YES"/>
         <attribute name="partnerType" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="region" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="representativeEmail" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="showDocumentsCount" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="size" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
         <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subscriptionState" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="website" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="admin" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="adminForPartner" inverseEntity="User" syncable="YES"/>
         <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Artwork" inverseName="partner" inverseEntity="Artwork">
             <userInfo/>
         </relationship>
+        <relationship name="flags" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PartnerOption" inverseName="partner" inverseEntity="PartnerOption" syncable="YES"/>
+        <relationship name="subscriptionPlans" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SubscriptionPlan" inverseName="subscriptionForPartner" inverseEntity="SubscriptionPlan" syncable="YES"/>
         <userInfo/>
+    </entity>
+    <entity name="PartnerOption" representedClassName="PartnerOption" syncable="YES">
+        <attribute name="key" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="value" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="partner" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Partner" inverseName="flags" inverseEntity="Partner" syncable="YES"/>
     </entity>
     <entity name="Show" representedClassName="Show" syncable="YES">
         <attribute name="availabilityPeriod" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="endsAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="showSlug" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="slug" attributeType="String" defaultValueString="unknown-slug" syncable="YES"/>
         <attribute name="sortKey" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
         <attribute name="startsAt" optional="YES" attributeType="Date" syncable="YES"/>
@@ -226,28 +280,55 @@
         <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="shows" inverseEntity="Artwork" syncable="YES"/>
         <relationship name="cover" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Image" inverseName="coverForShow" inverseEntity="Image" syncable="YES"/>
         <relationship name="documents" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Document" inverseName="show" inverseEntity="Document" syncable="YES"/>
-        <relationship name="installationImages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Image" inverseName="showWithImageInInstallation" inverseEntity="Image" syncable="YES"/>
+        <relationship name="installationImages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="InstallShotImage" inverseName="showWithImageInInstallation" inverseEntity="InstallShotImage" syncable="YES"/>
         <relationship name="location" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Location" inverseName="shows" inverseEntity="Location" syncable="YES"/>
     </entity>
     <entity name="ShowDocument" representedClassName="ShowDocument" parentEntity="Document" syncable="YES"/>
+    <entity name="SubscriptionPlan" representedClassName="SubscriptionPlan" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="subscriptionForPartner" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Partner" inverseName="subscriptionPlans" inverseEntity="Partner" syncable="YES"/>
+    </entity>
+    <entity name="SyncError" representedClassName="SyncError" syncable="YES">
+        <attribute name="body" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="errorType" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="syncLog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SyncLog" inverseName="syncErrors" inverseEntity="SyncLog" syncable="YES"/>
+    </entity>
+    <entity name="SyncLog" representedClassName="SyncLog" syncable="YES">
+        <attribute name="albumsDelta" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="artworkDelta" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="dateStarted" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="estimatedDownload" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="showDelta" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="timeToCompletion" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="totalDownloaded" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <relationship name="syncErrors" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SyncError" inverseName="syncLog" inverseEntity="SyncError" syncable="YES"/>
+    </entity>
     <entity name="User" representedClassName="User" syncable="YES">
         <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="type" optional="YES" attributeType="String" elementID="user_role" syncable="YES"/>
+        <relationship name="adminForPartner" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Partner" inverseName="admin" inverseEntity="Partner" syncable="YES"/>
     </entity>
     <elements>
-        <element name="Album" positionX="0" positionY="0" width="128" height="253"/>
-        <element name="Artist" positionX="0" positionY="0" width="128" height="403"/>
+        <element name="Album" positionX="0" positionY="0" width="128" height="255"/>
+        <element name="Artist" positionX="0" positionY="0" width="128" height="405"/>
         <element name="ArtistDocument" positionX="0" positionY="0" width="128" height="45"/>
-        <element name="Artwork" positionX="0" positionY="0" width="128" height="583"/>
-        <element name="Document" positionX="0" positionY="0" width="128" height="193"/>
-        <element name="Image" positionX="0" positionY="0" width="128" height="373"/>
-        <element name="Location" positionX="0" positionY="0" width="128" height="195"/>
+        <element name="Artwork" positionX="0" positionY="0" width="128" height="660"/>
+        <element name="Document" positionX="0" positionY="0" width="128" height="210"/>
+        <element name="EditionSet" positionX="27" positionY="162" width="128" height="330"/>
+        <element name="Image" positionX="0" positionY="0" width="128" height="360"/>
+        <element name="InstallShotImage" positionX="18" positionY="153" width="128" height="73"/>
+        <element name="LocalImage" positionX="18" positionY="162" width="128" height="45"/>
+        <element name="Location" positionX="0" positionY="0" width="128" height="210"/>
         <element name="Note" positionX="0" positionY="0" width="128" height="105"/>
-        <element name="Partner" positionX="0" positionY="0" width="128" height="240"/>
-        <element name="Show" positionX="0" positionY="0" width="128" height="270"/>
+        <element name="Partner" positionX="0" positionY="0" width="128" height="480"/>
+        <element name="PartnerOption" positionX="18" positionY="153" width="128" height="88"/>
+        <element name="Show" positionX="0" positionY="0" width="128" height="283"/>
         <element name="ShowDocument" positionX="0" positionY="0" width="128" height="45"/>
-        <element name="User" positionX="0" positionY="0" width="128" height="105"/>
+        <element name="SubscriptionPlan" positionX="27" positionY="162" width="128" height="73"/>
+        <element name="SyncError" positionX="9" positionY="153" width="128" height="88"/>
+        <element name="SyncLog" positionX="9" positionY="153" width="128" height="163"/>
+        <element name="User" positionX="0" positionY="0" width="128" height="120"/>
     </elements>
 </model>

--- a/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.5.1.xcdatamodel/contents
+++ b/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.5.1.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="2.5.1" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Automatic">
+<model userDefinedModelVersionIdentifier="2.5.1" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10174" systemVersion="15G24b" minimumToolsVersion="Automatic">
     <entity name="Album" representedClassName="Album" elementID="Collection">
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="editable" optional="YES" attributeType="Boolean" defaultValueString="YES" syncable="YES"/>
@@ -55,7 +55,7 @@
             <userInfo/>
         </attribute>
         <relationship name="albumsFeaturingArtist" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Album" inverseName="artists" inverseEntity="Album" syncable="YES"/>
-        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="artist" inverseEntity="Artwork">
+        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="artists" inverseEntity="Artwork">
             <userInfo/>
         </relationship>
         <relationship name="cover" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Image" inverseName="coverForArtist" inverseEntity="Image" syncable="YES"/>
@@ -124,10 +124,10 @@
         <attribute name="width" optional="YES" attributeType="Decimal" defaultValueString="0.0">
             <userInfo/>
         </attribute>
-        <relationship name="artist" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="artworks" inverseEntity="Artist">
+        <relationship name="artist" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Artist">
             <userInfo/>
         </relationship>
-        <relationship name="artists" optional="YES" toMany="YES" deletionRule="No Action" destinationEntity="Artist" syncable="YES"/>
+        <relationship name="artists" optional="YES" toMany="YES" deletionRule="No Action" destinationEntity="Artist" inverseName="artworks" inverseEntity="Artist" syncable="YES"/>
         <relationship name="collections" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Album" inverseName="artworks" inverseEntity="Album">
             <userInfo/>
         </relationship>

--- a/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.5.xcdatamodel/contents
+++ b/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyFolio v2.5.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="1" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9525" systemVersion="15D21" minimumToolsVersion="Automatic">
+<model userDefinedModelVersionIdentifier="2.5" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Automatic">
     <entity name="Album" representedClassName="Album" elementID="Collection">
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="editable" optional="YES" attributeType="Boolean" defaultValueString="YES" syncable="YES"/>

--- a/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyPartner 2.xcdatamodel/contents
+++ b/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyPartner 2.xcdatamodel/contents
@@ -1,62 +1,121 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model name="" userDefinedModelVersionIdentifier="1" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1171" systemVersion="11D50d" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="0.2" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Automatic">
     <entity name="Artist" representedClassName="Artist">
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
-        <attribute name="deathDate" optional="YES" attributeType="Date"/>
+        <attribute name="deathDate" optional="YES" attributeType="Date">
+            <userInfo/>
+        </attribute>
         <attribute name="displayName" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
         <attribute name="firstName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="middleName" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="name" optional="YES" attributeType="String" indexed="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="orderingKey" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="slug" attributeType="String" indexed="YES"/>
+        <attribute name="slug" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="thumbnailBaseURL" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
-        <attribute name="years" optional="YES" attributeType="String"/>
-        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="artist" inverseEntity="Artwork"/>
+        <attribute name="years" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="artist" inverseEntity="Artwork">
+            <userInfo/>
+        </relationship>
         <relationship name="thumbnail" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Image" inverseName="thumbnail" inverseEntity="Image" syncable="YES"/>
+        <userInfo/>
     </entity>
     <entity name="Artwork" representedClassName="Artwork">
-        <attribute name="category" optional="YES" attributeType="String" indexed="YES"/>
+        <attribute name="category" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
-        <attribute name="date" optional="YES" attributeType="String"/>
-        <attribute name="depth" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
-        <attribute name="diameter" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
-        <attribute name="dimensionsCM" optional="YES" attributeType="String"/>
-        <attribute name="dimensionsInches" optional="YES" attributeType="String"/>
-        <attribute name="displayPrice" optional="YES" attributeType="String"/>
-        <attribute name="displayTitle" optional="YES" attributeType="String"/>
+        <attribute name="date" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="depth" optional="YES" attributeType="Decimal" defaultValueString="0.0">
+            <userInfo/>
+        </attribute>
+        <attribute name="diameter" optional="YES" attributeType="Decimal" defaultValueString="0.0">
+            <userInfo/>
+        </attribute>
+        <attribute name="dimensionsCM" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="dimensionsInches" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="displayPrice" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="displayTitle" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
         <attribute name="editions" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="exhibitionHistory" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="height" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="height" optional="YES" attributeType="Decimal" defaultValueString="0.0">
+            <userInfo/>
+        </attribute>
         <attribute name="info" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="isForSale" optional="YES" attributeType="Boolean"/>
-        <attribute name="isPriceHidden" optional="YES" attributeType="Boolean"/>
+        <attribute name="isForSale" optional="YES" attributeType="Boolean">
+            <userInfo/>
+        </attribute>
+        <attribute name="isPriceHidden" optional="YES" attributeType="Boolean">
+            <userInfo/>
+        </attribute>
         <attribute name="isPublished" optional="YES" attributeType="Boolean" syncable="YES"/>
-        <attribute name="medium" optional="YES" attributeType="String"/>
+        <attribute name="medium" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
         <attribute name="provenance" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="series" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="slug" optional="YES" attributeType="String" indexed="YES"/>
-        <attribute name="title" optional="YES" attributeType="String" indexed="YES"/>
+        <attribute name="slug" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="title" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
-        <attribute name="width" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
-        <relationship name="artist" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="artworks" inverseEntity="Artist"/>
-        <relationship name="collections" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Collection" inverseName="artworks" inverseEntity="Collection"/>
+        <attribute name="width" optional="YES" attributeType="Decimal" defaultValueString="0.0">
+            <userInfo/>
+        </attribute>
+        <relationship name="artist" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="artworks" inverseEntity="Artist">
+            <userInfo/>
+        </relationship>
+        <relationship name="collections" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Collection" inverseName="artworks" inverseEntity="Collection">
+            <userInfo/>
+        </relationship>
         <relationship name="images" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Image" inverseName="artwork" inverseEntity="Image" syncable="YES"/>
         <relationship name="notes" optional="YES" minCount="1" maxCount="1" deletionRule="Cascade" destinationEntity="Note" inverseName="artwork" inverseEntity="Note" syncable="YES"/>
-        <relationship name="partner" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Partner" inverseName="artworks" inverseEntity="Partner"/>
+        <relationship name="partner" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Partner" inverseName="artworks" inverseEntity="Partner">
+            <userInfo/>
+        </relationship>
+        <userInfo/>
     </entity>
     <entity name="Collection" representedClassName="Collection">
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="hasBeenEdited" optional="YES" attributeType="Boolean" syncable="YES"/>
-        <attribute name="isPrivate" optional="YES" attributeType="Boolean"/>
-        <attribute name="name" optional="YES" attributeType="String" indexed="YES"/>
-        <attribute name="slug" optional="YES" attributeType="String" indexed="YES"/>
+        <attribute name="isPrivate" optional="YES" attributeType="Boolean">
+            <userInfo/>
+        </attribute>
+        <attribute name="name" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="slug" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="sortKey" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
-        <attribute name="summary" optional="YES" attributeType="String"/>
+        <attribute name="summary" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
         <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
-        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="collections" inverseEntity="Artwork"/>
+        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="collections" inverseEntity="Artwork">
+            <userInfo/>
+        </relationship>
+        <userInfo/>
     </entity>
     <entity name="Image" representedClassName="Image" syncable="YES">
         <attribute name="baseURL" attributeType="String" syncable="YES"/>
@@ -83,11 +142,16 @@
         <attribute name="artworksCount" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="name" optional="YES" attributeType="String" indexed="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="website" optional="YES" attributeType="String" syncable="YES"/>
-        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Artwork" inverseName="partner" inverseEntity="Artwork"/>
+        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Artwork" inverseName="partner" inverseEntity="Artwork">
+            <userInfo/>
+        </relationship>
+        <userInfo/>
     </entity>
     <entity name="User" representedClassName="User" syncable="YES">
         <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>

--- a/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyPartner 3.xcdatamodel/contents
+++ b/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyPartner 3.xcdatamodel/contents
@@ -1,68 +1,127 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model name="" userDefinedModelVersionIdentifier="1" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1171" systemVersion="11D50d" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="0.3" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Automatic">
     <entity name="Artist" representedClassName="Artist">
         <attribute name="awards" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="biography" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="blurb" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
-        <attribute name="deathDate" optional="YES" attributeType="Date"/>
+        <attribute name="deathDate" optional="YES" attributeType="Date">
+            <userInfo/>
+        </attribute>
         <attribute name="displayName" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
         <attribute name="firstName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="hometown" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="middleName" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="name" optional="YES" attributeType="String" indexed="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="nationality" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="orderingKey" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="slug" attributeType="String" indexed="YES"/>
+        <attribute name="slug" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="statement" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="thumbnailBaseURL" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
-        <attribute name="years" optional="YES" attributeType="String"/>
-        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="artist" inverseEntity="Artwork"/>
+        <attribute name="years" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="artist" inverseEntity="Artwork">
+            <userInfo/>
+        </relationship>
         <relationship name="thumbnail" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Image" inverseName="thumbnail" inverseEntity="Image" syncable="YES"/>
+        <userInfo/>
     </entity>
     <entity name="Artwork" representedClassName="Artwork">
-        <attribute name="category" optional="YES" attributeType="String" indexed="YES"/>
+        <attribute name="category" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
-        <attribute name="date" optional="YES" attributeType="String"/>
-        <attribute name="depth" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
-        <attribute name="diameter" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
-        <attribute name="dimensionsCM" optional="YES" attributeType="String"/>
-        <attribute name="dimensionsInches" optional="YES" attributeType="String"/>
-        <attribute name="displayPrice" optional="YES" attributeType="String"/>
-        <attribute name="displayTitle" optional="YES" attributeType="String"/>
+        <attribute name="date" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="depth" optional="YES" attributeType="Decimal" defaultValueString="0.0">
+            <userInfo/>
+        </attribute>
+        <attribute name="diameter" optional="YES" attributeType="Decimal" defaultValueString="0.0">
+            <userInfo/>
+        </attribute>
+        <attribute name="dimensionsCM" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="dimensionsInches" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="displayPrice" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="displayTitle" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
         <attribute name="editions" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="exhibitionHistory" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="height" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="height" optional="YES" attributeType="Decimal" defaultValueString="0.0">
+            <userInfo/>
+        </attribute>
         <attribute name="info" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="isForSale" optional="YES" attributeType="Boolean"/>
-        <attribute name="isPriceHidden" optional="YES" attributeType="Boolean"/>
+        <attribute name="isForSale" optional="YES" attributeType="Boolean">
+            <userInfo/>
+        </attribute>
+        <attribute name="isPriceHidden" optional="YES" attributeType="Boolean">
+            <userInfo/>
+        </attribute>
         <attribute name="isPublished" optional="YES" attributeType="Boolean" syncable="YES"/>
-        <attribute name="medium" optional="YES" attributeType="String"/>
+        <attribute name="medium" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
         <attribute name="provenance" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="series" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="slug" optional="YES" attributeType="String" indexed="YES"/>
-        <attribute name="title" optional="YES" attributeType="String" indexed="YES"/>
+        <attribute name="slug" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="title" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
-        <attribute name="width" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
-        <relationship name="artist" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="artworks" inverseEntity="Artist"/>
-        <relationship name="collections" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Collection" inverseName="artworks" inverseEntity="Collection"/>
+        <attribute name="width" optional="YES" attributeType="Decimal" defaultValueString="0.0">
+            <userInfo/>
+        </attribute>
+        <relationship name="artist" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="artworks" inverseEntity="Artist">
+            <userInfo/>
+        </relationship>
+        <relationship name="collections" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Collection" inverseName="artworks" inverseEntity="Collection">
+            <userInfo/>
+        </relationship>
         <relationship name="images" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Image" inverseName="artwork" inverseEntity="Image" syncable="YES"/>
         <relationship name="notes" optional="YES" minCount="1" maxCount="1" deletionRule="Cascade" destinationEntity="Note" inverseName="artwork" inverseEntity="Note" syncable="YES"/>
-        <relationship name="partner" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Partner" inverseName="artworks" inverseEntity="Partner"/>
+        <relationship name="partner" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Partner" inverseName="artworks" inverseEntity="Partner">
+            <userInfo/>
+        </relationship>
+        <userInfo/>
     </entity>
     <entity name="Collection" representedClassName="Collection">
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="hasBeenEdited" optional="YES" attributeType="Boolean" syncable="YES"/>
-        <attribute name="isPrivate" optional="YES" attributeType="Boolean"/>
-        <attribute name="name" optional="YES" attributeType="String" indexed="YES"/>
-        <attribute name="slug" optional="YES" attributeType="String" indexed="YES"/>
+        <attribute name="isPrivate" optional="YES" attributeType="Boolean">
+            <userInfo/>
+        </attribute>
+        <attribute name="name" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="slug" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="sortKey" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
-        <attribute name="summary" optional="YES" attributeType="String"/>
+        <attribute name="summary" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
         <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
-        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="collections" inverseEntity="Artwork"/>
+        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="collections" inverseEntity="Artwork">
+            <userInfo/>
+        </relationship>
+        <userInfo/>
     </entity>
     <entity name="Image" representedClassName="Image" syncable="YES">
         <attribute name="baseURL" attributeType="String" syncable="YES"/>
@@ -89,11 +148,16 @@
         <attribute name="artworksCount" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="name" optional="YES" attributeType="String" indexed="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="website" optional="YES" attributeType="String" syncable="YES"/>
-        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Artwork" inverseName="partner" inverseEntity="Artwork"/>
+        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Artwork" inverseName="partner" inverseEntity="Artwork">
+            <userInfo/>
+        </relationship>
+        <userInfo/>
     </entity>
     <entity name="User" representedClassName="User" syncable="YES">
         <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>

--- a/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyPartner 4.xcdatamodel/contents
+++ b/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyPartner 4.xcdatamodel/contents
@@ -1,70 +1,129 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model name="" userDefinedModelVersionIdentifier="1" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1171" systemVersion="11D50b" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="0.5" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Automatic">
     <entity name="Artist" representedClassName="Artist">
         <attribute name="awards" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="biography" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="blurb" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
-        <attribute name="deathDate" optional="YES" attributeType="Date"/>
+        <attribute name="deathDate" optional="YES" attributeType="Date">
+            <userInfo/>
+        </attribute>
         <attribute name="displayName" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
         <attribute name="firstName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="hometown" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="middleName" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="name" optional="YES" attributeType="String" indexed="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="nationality" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="orderingKey" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="slug" attributeType="String" indexed="YES"/>
+        <attribute name="slug" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="statement" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="thumbnailBaseURL" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
-        <attribute name="years" optional="YES" attributeType="String"/>
-        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="artist" inverseEntity="Artwork"/>
+        <attribute name="years" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="artist" inverseEntity="Artwork">
+            <userInfo/>
+        </relationship>
         <relationship name="cover" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Artwork" syncable="YES"/>
         <relationship name="thumbnail" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Image" inverseName="thumbnail" inverseEntity="Image" syncable="YES"/>
+        <userInfo/>
     </entity>
     <entity name="Artwork" representedClassName="Artwork">
-        <attribute name="category" optional="YES" attributeType="String" indexed="YES"/>
+        <attribute name="category" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
-        <attribute name="date" optional="YES" attributeType="String"/>
-        <attribute name="depth" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
-        <attribute name="diameter" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
-        <attribute name="dimensionsCM" optional="YES" attributeType="String"/>
-        <attribute name="dimensionsInches" optional="YES" attributeType="String"/>
-        <attribute name="displayPrice" optional="YES" attributeType="String"/>
-        <attribute name="displayTitle" optional="YES" attributeType="String"/>
+        <attribute name="date" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="depth" optional="YES" attributeType="Decimal" defaultValueString="0.0">
+            <userInfo/>
+        </attribute>
+        <attribute name="diameter" optional="YES" attributeType="Decimal" defaultValueString="0.0">
+            <userInfo/>
+        </attribute>
+        <attribute name="dimensionsCM" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="dimensionsInches" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="displayPrice" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="displayTitle" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
         <attribute name="editions" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="exhibitionHistory" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="height" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="height" optional="YES" attributeType="Decimal" defaultValueString="0.0">
+            <userInfo/>
+        </attribute>
         <attribute name="info" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="isForSale" optional="YES" attributeType="Boolean"/>
-        <attribute name="isPriceHidden" optional="YES" attributeType="Boolean"/>
+        <attribute name="isForSale" optional="YES" attributeType="Boolean">
+            <userInfo/>
+        </attribute>
+        <attribute name="isPriceHidden" optional="YES" attributeType="Boolean">
+            <userInfo/>
+        </attribute>
         <attribute name="isPublished" optional="YES" attributeType="Boolean" syncable="YES"/>
-        <attribute name="medium" optional="YES" attributeType="String"/>
+        <attribute name="medium" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
         <attribute name="provenance" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="series" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="slug" optional="YES" attributeType="String" indexed="YES"/>
-        <attribute name="title" optional="YES" attributeType="String" indexed="YES"/>
+        <attribute name="slug" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="title" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
-        <attribute name="width" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
-        <relationship name="artist" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="artworks" inverseEntity="Artist"/>
-        <relationship name="collections" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Collection" inverseName="artworks" inverseEntity="Collection"/>
+        <attribute name="width" optional="YES" attributeType="Decimal" defaultValueString="0.0">
+            <userInfo/>
+        </attribute>
+        <relationship name="artist" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="artworks" inverseEntity="Artist">
+            <userInfo/>
+        </relationship>
+        <relationship name="collections" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Collection" inverseName="artworks" inverseEntity="Collection">
+            <userInfo/>
+        </relationship>
         <relationship name="images" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Image" inverseName="artwork" inverseEntity="Image" syncable="YES"/>
         <relationship name="notes" optional="YES" minCount="1" maxCount="1" deletionRule="Cascade" destinationEntity="Note" inverseName="artwork" inverseEntity="Note" syncable="YES"/>
-        <relationship name="partner" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Partner" inverseName="artworks" inverseEntity="Partner"/>
+        <relationship name="partner" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Partner" inverseName="artworks" inverseEntity="Partner">
+            <userInfo/>
+        </relationship>
+        <userInfo/>
     </entity>
     <entity name="Collection" representedClassName="Collection">
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="hasBeenEdited" optional="YES" attributeType="Boolean" syncable="YES"/>
-        <attribute name="isPrivate" optional="YES" attributeType="Boolean"/>
-        <attribute name="name" optional="YES" attributeType="String" indexed="YES"/>
-        <attribute name="slug" optional="YES" attributeType="String" indexed="YES"/>
+        <attribute name="isPrivate" optional="YES" attributeType="Boolean">
+            <userInfo/>
+        </attribute>
+        <attribute name="name" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="slug" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="sortKey" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
-        <attribute name="summary" optional="YES" attributeType="String"/>
+        <attribute name="summary" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
         <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
-        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="collections" inverseEntity="Artwork"/>
+        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="collections" inverseEntity="Artwork">
+            <userInfo/>
+        </relationship>
         <relationship name="cover" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Artwork" syncable="YES"/>
+        <userInfo/>
     </entity>
     <entity name="Image" representedClassName="Image" syncable="YES">
         <attribute name="baseURL" attributeType="String" syncable="YES"/>
@@ -91,11 +150,16 @@
         <attribute name="artworksCount" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="name" optional="YES" attributeType="String" indexed="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
         <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="website" optional="YES" attributeType="String" syncable="YES"/>
-        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Artwork" inverseName="partner" inverseEntity="Artwork"/>
+        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Artwork" inverseName="partner" inverseEntity="Artwork">
+            <userInfo/>
+        </relationship>
+        <userInfo/>
     </entity>
     <entity name="User" representedClassName="User" syncable="YES">
         <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>

--- a/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyPartner 5.xcdatamodel/contents
+++ b/Resources/CoreData/ArtsyPartner.xcdatamodeld/ArtsyPartner 5.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model name="" userDefinedModelVersionIdentifier="1" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1810" systemVersion="12C54" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="0.5" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Automatic">
     <entity name="Artist" representedClassName="Artist">
         <attribute name="awards" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="biography" optional="YES" attributeType="String" syncable="YES"/>

--- a/Resources/email_artwork_template.html
+++ b/Resources/email_artwork_template.html
@@ -24,7 +24,7 @@
                 {{/additionalImages}}
 
                 <div style="text-align:left; margin-top:8px; margin-bottom:16px;">
-                    <p style="font-family: Georgia,serif; font-weight:100;margin-bottom:0px;margin-top:0px;">{{artwork.artist.name.uppercaseString}}</p>
+                    <p style="font-family: Georgia,serif; font-weight:100;margin-bottom:0px;margin-top:0px;">{{artwork.artistDisplayString.uppercaseString}}</p>
 
                     {{#artwork.date}}
                         <p style="font-family: Georgia,serif; font-weight:100;margin-bottom:0px;margin-top:0px;">{{#artwork.title}}<em>{{artwork.title}}</em>, {{/artwork.title}}{{artwork.date}}</p>

--- a/Supporting Files/Info.plist
+++ b/Supporting Files/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5.0</string>
+	<string>2.5.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/docs/CHANGELOG.yml
+++ b/docs/CHANGELOG.yml
@@ -1,10 +1,10 @@
 upcoming:
-    version: 2.5.2
-    notes:
+  version: 2.5.2
+  notes:
     - Supports Artworks with multiple Artists - orta
 
 releases:
-   - version: 2.5.1
+  - version: 2.5.1
     date: Jun 30, 2016
     notes:
     - Improved sync timing algorithm by weighing it towards the timing of the last sync - orta

--- a/docs/CHANGELOG.yml
+++ b/docs/CHANGELOG.yml
@@ -1,6 +1,12 @@
 upcoming:
-  version: 2.5.1
-  notes:
+    version: 2.5.2
+    notes:
+    - Supports Artworks with multiple Artists - orta
+
+releases:
+   - version: 2.5.1
+    date: Jun 30, 2016
+    notes:
     - Improved sync timing algorithm by weighing it towards the timing of the last sync - orta
     - Ensure custom cc emails are not overwritten - orta
     - Partner Size now is a number, not a string - orta
@@ -11,7 +17,6 @@ upcoming:
     - Use a different API route for pinging Artsy, and ensure the timer stops when sync settings is not active - orta
     - Minor analytics updates - orta
 
-releases:
   - version: 2.5.0
     date: Jan 26 2016
     notes:


### PR DESCRIPTION
This adds the initial data model changes for the Core Data DB to allow supporting both `artist` and `artists` - I wanted to make sure that we retained complete backwards compatibility with existing setups, so most places that would show two artists fall back to the `artist` if `artists` is empty. 

### TODO: 
- [x] Test with a real artwork with multiple artists
- [x] Add more tests
- [x] Think about the core data merge conflict that will arise from this and #189 

### NOTES:

Folio Test Partner now has a multi-artist artwork called "Multiple Artist Work, hopefully" ( [CMS link](https://cms.artsy.net/artworks/57277ed2139b2112710039fd) ) - ALAN SMITHEE, ABE AJAX, TEST ARTIST

### Other notes

* This PR seems to also do https://github.com/artsy/energy/issues/204, https://github.com/artsy/energy/issues/195, https://github.com/artsy/energy/issues/174
* And it replaces the ARDocumentViewController with one that uses ChildViewControllers, which fixes a toolbar bug