### PR TITLE
Convert to using a less resource intense API route for network quality 

### DIFF
--- a/Classes/Constants/ARNetworkConstants.m
+++ b/Classes/Constants/ARNetworkConstants.m
@@ -4,7 +4,7 @@ NSString *const ARBaseURL = @"https://api.artsy.net";
 
 NSString *const ARStaticBaseURL = @"http://static.artsy.net";
 
-NSString *const ARSiteUpURL = @"/api/v1/system/up";
+NSString *const ARSiteUpURL = @"/api/v1/system/ping";
 
 
 NSString *const ARArtworkURLFormat = @"/api/v1/artwork/%@";

--- a/Classes/Controllers/Settings/ARSyncSettingsViewController.m
+++ b/Classes/Controllers/Settings/ARSyncSettingsViewController.m
@@ -228,4 +228,10 @@
     return _viewModel;
 }
 
+- (void)viewDidDisappear:(BOOL)animated
+{
+    [self.viewModel.qualityIndicator stopObservingNetworkQuality];
+    [super viewDidDisappear:animated];
+}
+
 @end

--- a/docs/CHANGELOG.yml
+++ b/docs/CHANGELOG.yml
@@ -7,6 +7,7 @@ upcoming:
       - Show a link to Artsy when a work is published in emails [orta]
       - Improvements to the Document preview [orta]
       - Minor copy update on the syncVC [orta]
+      - Use a different API route for pinging Artsy, and ensure the timer stops when sync settings is not active [orta]
 
 releases:
   - version: 2.5.0


### PR DESCRIPTION
Fixes #198

We were over retaining the networking and so it wasn't being disconnected when you let the sync screen. Resulting in more traffic than expected,

/cc @joeyAghion - sorry it took so long to get around to https://github.com/artsy/energy/pull/116#issuecomment-215579062