### PR TITLE
Per-Event Analytics Improvements

### DIFF
--- a/Classes/Util/Debugging/ARAnalyticsHelper.m
+++ b/Classes/Util/Debugging/ARAnalyticsHelper.m
@@ -128,8 +128,9 @@ static NSString *currentUserEmail;
     [Intercom registerUserWithUserId:user.slug email:user.email ?: @""];
 
     [ARAnalytics addEventSuperProperties:@{
-        @"user_email" : user.email ?: @"",
+        @"email" : user.email ?: @"",
         @"user_type" : user.type ?: @"",
+        @"user_id" : user.slug ?: @""
     }];
 
     [Intercom updateUserWithAttributes:@{

--- a/docs/CHANGELOG.yml
+++ b/docs/CHANGELOG.yml
@@ -8,6 +8,7 @@ upcoming:
       - Improvements to the Document preview [orta]
       - Minor copy update on the syncVC [orta]
       - Use a different API route for pinging Artsy, and ensure the timer stops when sync settings is not active [orta]
+      - Minor analytics updates [orta]
 
 releases:
   - version: 2.5.0


### PR DESCRIPTION
Fixes #202 

I *think* this was so that it was easier to track an individual event to either a partner or a user throughout the analytics pipeline. #trivial