### PR TITLE
Add a hot-fix for VIR iPad Pro sizes - fixes #102 #200

### DIFF
--- a/Classes/Artwork/View In Room/ARPadViewInRoomViewController.m
+++ b/Classes/Artwork/View In Room/ARPadViewInRoomViewController.m
@@ -30,6 +30,13 @@
     closeButton.titleEdgeInsets = UIEdgeInsetsMake(9, 0, 8, 0);
     _roomView.artwork = _artwork;
     _roomView.roomOrientation = self.interfaceOrientation;
+
+    if ([UIDevice isPadPro]) {
+        _roomView.frame = CGRectOffset(_roomView.frame, 0, -200);
+        CGAffineTransform transform = _roomView.transform;
+        _roomView.transform = CGAffineTransformScale(transform, 1.5, 1.5);
+    }
+
     [super viewDidLoad];
 }
 

--- a/Classes/Categories/UIDevice+deviceInfo.h
+++ b/Classes/Categories/UIDevice+deviceInfo.h
@@ -27,6 +27,8 @@ typedef NS_ENUM(NSInteger, UIDeviceType) {
 
 + (BOOL)isPhone;
 
++ (BOOL)isPadPro;
+
 + (BOOL)isIOS8Plus;
 
 @end

--- a/Classes/Categories/UIDevice+deviceInfo.m
+++ b/Classes/Categories/UIDevice+deviceInfo.m
@@ -15,6 +15,13 @@
     return UI_USER_INTERFACE_IDIOM() != UIUserInterfaceIdiomPhone;
 }
 
++ (BOOL)isPadPro
+{
+    CGFloat longestEdge = MAX(CGRectGetWidth([UIScreen mainScreen].bounds), CGRectGetHeight([UIScreen mainScreen].bounds));
+    return [self isPad] && longestEdge == 1366;
+}
+
+
 + (BOOL)isPhone
 {
     return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone;

--- a/docs/CHANGELOG.yml
+++ b/docs/CHANGELOG.yml
@@ -2,6 +2,7 @@ upcoming:
   version: 2.5.3
   notes:
     - Crash fixes around spolight exporting - orta
+    - Fixed iPad Pro View in Room - orta
 
 releases:
 


### PR DESCRIPTION
![screen shot 2016-08-31 at 11 43 54 am](https://cloud.githubusercontent.com/assets/49038/18135679/b17eae40-6f70-11e6-84c8-045375116194.png)

![screen shot 2016-08-31 at 11 43 31 am](https://cloud.githubusercontent.com/assets/49038/18135682/b2780ed6-6f70-11e6-881a-0f9460f5e1f1.png)

This is not a _perfect_ answer, as effectively is zooms in a bit to ensure everything fits, but it is using retina images, so it feels fine on an iPad.