### PR TITLE
Call out staff flag earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You will have a running version of the Artsy app by hitting `Build > Run`.
 ### Work at Artsy?
 
 - Instead of `make oss` in the above, run `make artsy` to set up [spacecommander](https://github.com/square/spacecommander).
-- Set an environment variable of `ARTSY_STAFF_MEMBER` to `true`.
+- Set an environment variable of `ARTSY_STAFF_MEMBER` to `true`. Be sure to do this before installing pods.
 - Run `bundle exec pod install`. More info [here](https://guides.cocoapods.org/using/a-gemfile.html), if you're curious.
 
 ### Troubleshooting

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -9,6 +9,12 @@ run the installer.
 
 You need Xcode 7 with the latest iOS simulator installed.
 
+## Set Staff Flag
+
+If you're installing as an open source contributor, skip this step. If you work
+for Artsy, set an environment variable of `ARTSY_STAFF_MEMBER` to `true`. Make
+sure you do this before you install pods.
+
 ## Energy
 
 We don't run off forks, as this is an OSS project
@@ -31,9 +37,7 @@ If you are setting up as an employee, run this:
 $ make artsy
 ```
 
-And be sure to set an environment variable of `ARTSY_STAFF_MEMBER` to `true`.
-
-If you're setting up as an Open Source contributor, run this:
+And if you're setting up as an Open Source contributor, run this:
 
 ```
 $ make oss


### PR DESCRIPTION
With af3d259 I moved the staff stuff together, but upon further investigation, this was wrong. If you don't set that flag prior to installing pods you'll get the wrong fonts and be confused. This happened to me and I fixed it by accident. Later, I was reading the Podfile and figured out what happened.

This commit calls attention to the flag being set before the pods are installed.