### PR TITLE
Update LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,13 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2017 Art.sy, Inc.
+Copyright (c) 2012-2017 Art.sy, Inc.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,4 @@ Thanks to all [our contributors](/docs/THANKS.md).
 
 ## License
 
-Copyright (c) 2012-2017 Art.sy, Inc.
-
 MIT License. See [LICENSE](LICENSE).


### PR DESCRIPTION
Ok, last PR on license/copyright stuff today, promise! Turns out the copyright line belongs in the LICENSE file and that should be the single source of truth for this info. While I was at it, I updated the copy slightly to match the default copy from the GitHub template.