### PR TITLE
Fix email tint bug

### DIFF
--- a/Classes/Artwork/Paging/ARArtworkSetViewController.m
+++ b/Classes/Artwork/Paging/ARArtworkSetViewController.m
@@ -14,6 +14,7 @@
 #import "ARImageViewController.h"
 #import "ARModernEmailArtworksViewController.h"
 #import "AROptions.h"
+#import "ARTheme.h"
 
 #if __has_include(<SafariServices/SafariServices.h>)
 @import SafariServices;
@@ -352,6 +353,8 @@
         default:;
     }
 
+    UIWindow *window = [[UIApplication sharedApplication] keyWindow];
+    [ARTheme setupWindowTintOnWindow:window];
     [self dismissViewControllerAnimated:YES completion:nil];
     self.emailButton.representedButton.selected = NO;
     [self.emailPopoverController dismissPopoverAnimated:YES];

--- a/Classes/Artwork/Paging/ARArtworkSetViewController.m
+++ b/Classes/Artwork/Paging/ARArtworkSetViewController.m
@@ -353,8 +353,7 @@
         default:;
     }
 
-    UIWindow *window = [[UIApplication sharedApplication] keyWindow];
-    [ARTheme setupWindowTintOnWindow:window];
+    [ARTheme resetWindowTint];
     [self dismissViewControllerAnimated:YES completion:nil];
     self.emailButton.representedButton.selected = NO;
     [self.emailPopoverController dismissPopoverAnimated:YES];

--- a/Classes/Controllers/Collections Controllers/Hosts/ARHostViewController.m
+++ b/Classes/Controllers/Collections Controllers/Hosts/ARHostViewController.m
@@ -251,8 +251,7 @@
             ;
     }
 
-    UIWindow *window = [[UIApplication sharedApplication] keyWindow];
-    [ARTheme setupWindowTintOnWindow:window];
+    [ARTheme resetWindowTint];
     [self dismissPopoversAnimated:YES];
     [self dismissViewControllerAnimated:YES completion:nil];
     [self endSelecting];

--- a/Classes/Controllers/Collections Controllers/Hosts/ARHostViewController.m
+++ b/Classes/Controllers/Collections Controllers/Hosts/ARHostViewController.m
@@ -14,6 +14,7 @@
 #import "ARPopoverController.h"
 #import "ARModernEmailArtworksViewController.h"
 #import "InstallShotImage.h"
+#import "ARTheme.h"
 
 
 @interface ARHostViewController () <ARModalAlertViewControllerDelegate>
@@ -250,6 +251,8 @@
             ;
     }
 
+    UIWindow *window = [[UIApplication sharedApplication] keyWindow];
+    [ARTheme setupWindowTintOnWindow:window];
     [self dismissPopoversAnimated:YES];
     [self dismissViewControllerAnimated:YES completion:nil];
     [self endSelecting];

--- a/Classes/Theming/ARTheme.h
+++ b/Classes/Theming/ARTheme.h
@@ -13,4 +13,6 @@
 
 + (void)resetWindowTint;
 
++ (void)setWindowTint:(UIColor *)tintColor;
+
 @end

--- a/Classes/Theming/ARTheme.h
+++ b/Classes/Theming/ARTheme.h
@@ -11,4 +11,6 @@
 /// by changing it on the window.
 + (void)setupWindowTintOnWindow:(UIWindow *)window;
 
++ (void)resetWindowTint;
+
 @end

--- a/Classes/Theming/ARTheme.m
+++ b/Classes/Theming/ARTheme.m
@@ -30,6 +30,12 @@
     window.backgroundColor = [UIColor artsyBackgroundColor];
 }
 
++ (void)resetWindowTintOnWindow
+{
+    UIWindow *window = [[UIApplication sharedApplication] keyWindow];
+    [self setupWindowTintOnWindow:window];
+}
+
 + (void)setupMailViewControllerButtons
 {
     [[UIBarButtonItem appearanceWhenContainedIn:MFMailComposeViewController.class, nil] setTitleTextAttributes:@{

--- a/Classes/Theming/ARTheme.m
+++ b/Classes/Theming/ARTheme.m
@@ -36,6 +36,12 @@
     [self setupWindowTintOnWindow:window];
 }
 
++ (void)setWindowTint:(UIColor *)tintColor
+{
+    UIWindow *window = [[UIApplication sharedApplication] keyWindow];
+    window.tintColor = tintColor;
+}
+
 + (void)setupMailViewControllerButtons
 {
     [[UIBarButtonItem appearanceWhenContainedIn:MFMailComposeViewController.class, nil] setTitleTextAttributes:@{

--- a/Classes/Util/Emails/AREmailComposer.m
+++ b/Classes/Util/Emails/AREmailComposer.m
@@ -108,6 +108,8 @@
     self.mailController.mailComposeDelegate = self.parentViewController;
     [self.mailController.navigationBar setTintColor:[UIColor blackColor]];
 
+    UIWindow *window = [[UIApplication sharedApplication] keyWindow];
+    window.tintColor = [UIColor blackColor];
     [self.parentViewController presentViewController:self.mailController animated:YES completion:nil];
 }
 

--- a/Classes/Util/Emails/AREmailComposer.m
+++ b/Classes/Util/Emails/AREmailComposer.m
@@ -108,6 +108,9 @@
     self.mailController.mailComposeDelegate = self.parentViewController;
     [self.mailController.navigationBar setTintColor:[UIColor blackColor]];
 
+    // White window tint causes the fields in the mailController to
+    // behave strangely - this forces the tint to black and is reversed
+    // in the delegate.
     [ARTheme setWindowTint:[UIColor blackColor]];
     [self.parentViewController presentViewController:self.mailController animated:YES completion:nil];
 }

--- a/Classes/Util/Emails/AREmailComposer.m
+++ b/Classes/Util/Emails/AREmailComposer.m
@@ -1,6 +1,6 @@
 #import <GRMustache/GRMustache.h>
 #import "AREmailComposer.h"
-
+#import "ARTheme.h"
 
 @interface AREmailComposer ()
 @property (nonatomic, strong) UIViewController<MFMailComposeViewControllerDelegate> *parentViewController;
@@ -108,8 +108,7 @@
     self.mailController.mailComposeDelegate = self.parentViewController;
     [self.mailController.navigationBar setTintColor:[UIColor blackColor]];
 
-    UIWindow *window = [[UIApplication sharedApplication] keyWindow];
-    window.tintColor = [UIColor blackColor];
+    [ARTheme setWindowTint:[UIColor blackColor]];
     [self.parentViewController presentViewController:self.mailController animated:YES completion:nil];
 }
 

--- a/docs/CHANGELOG.yml
+++ b/docs/CHANGELOG.yml
@@ -1,4 +1,7 @@
 upcoming:
+  version: 2.5.6
+  notes:
+    - Fix email tint bug - jonallured
 
 releases:
   - version: 2.5.5

--- a/docs/CHANGELOG.yml
+++ b/docs/CHANGELOG.yml
@@ -1,11 +1,12 @@
 upcoming:
-  version: 2.5.5
-  notes:
-    - Sync stability improvement - orta/jonallured
-    - Failed images will be removed from local cache  - orta/jonallured
-    - (dev) Update Fonts, Xcode version - orta
 
 releases:
+  - version: 2.5.5
+    date: Apr 5, 2017
+    notes:
+      - Sync stability improvement - orta/jonallured
+      - Failed images will be removed from local cache  - orta/jonallured
+      - (dev) Update Fonts, Xcode version - orta
 
   - version: 2.5.4
     date: Aug 31, 2016


### PR DESCRIPTION
In #271 @starsirius found that the mail compose view would "lose" the value of the to field on blur. Turns out that this was a side-effect of setting the tint color on Window. This PR addresses the bug by forcing the tint color to be black prior to presenting the mail composer view and then switching it back to whatever it was on dismissal of that view.

Technically speaking all that's required here is 3253c2a, but it felt weird to not extract some helper methods, so that's what I did with 64ac201 and fb37924. Interested in feedback on this!