### PR TITLE
Adds a crash fix for when you *somehow* have no stored username/password

### DIFF
--- a/Classes/ARAppDelegate.m
+++ b/Classes/ARAppDelegate.m
@@ -112,7 +112,11 @@ void uncaughtExceptionHandler(NSException *exception);
     } else if (hasLoggedInSyncedUser && !hasLoggedInUnsyncedUser) {
         if (!loggedIn) {
             // run like normal but update token in background
-            [self updateExpiredAuthToken];
+            if(![self updateExpiredAuthToken]) {
+                // If it couldn't update the token, show the login screen
+                [self.viewCoordinator presentLoginScreen:NO];
+                return YES;
+            };
         }
 
         [ARAnalytics identifyUserWithID:[User currentUser].slug andEmailAddress:[User currentUser].email];
@@ -205,11 +209,11 @@ void uncaughtExceptionHandler(NSException *exception);
     #endif
 }
 
-- (void)updateExpiredAuthToken
+- (BOOL)updateExpiredAuthToken
 {
     // let them through into the app whilst it re-auths in the background.
     [ARAnalytics event:@"Updating auth token"];
-    [self.userManager requestLoginWithStoredCredentials];
+    return [self.userManager requestLoginWithStoredCredentials];
 }
 
 #pragma mark -

--- a/Classes/Sync/Partner & User Metadata/ARPartnerFullMetadataDownloader.m
+++ b/Classes/Sync/Partner & User Metadata/ARPartnerFullMetadataDownloader.m
@@ -37,7 +37,6 @@
     @weakify(self);
     [operation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
         @strongify(self);
-
         [ARFeedTranslator backgroundAddOrUpdateObjects:@[ responseObject ] withClass:Partner.class inContext:self.context saving:NO completion:^(NSArray *objects) {
             Partner *partner = objects.firstObject;
             [[NSNotificationCenter defaultCenter] postNotificationName:ARPartnerUpdatedNotification object:partner userInfo:@{ ARPartnerKey: partner }];

--- a/Classes/Util/App/ARUserManager.h
+++ b/Classes/Util/App/ARUserManager.h
@@ -14,7 +14,7 @@
 - (BOOL)userCredentialsExist;
 
 /// Uses the stored credentials to log in transparently
-- (void)requestLoginWithStoredCredentials;
+- (BOOL)requestLoginWithStoredCredentials;
 
 /// Logs in with the username / password
 - (void)requestLoginWithUsername:(NSString *)username andPassword:(NSString *)password completion:(void (^)(BOOL success, NSError *error))completion;

--- a/Classes/Util/App/ARUserManager.m
+++ b/Classes/Util/App/ARUserManager.m
@@ -38,11 +38,16 @@
     [self.userDefaults removeObjectForKey:AROAuthTokenExpiryDate];
 }
 
-- (void)requestLoginWithStoredCredentials
+- (BOOL)requestLoginWithStoredCredentials
 {
     NSString *username = [self.userDefaults valueForKey:ARUserEmailAddress];
     NSString *password = [SFHFKeychainUtils getPasswordForUsername:username andServiceName:ARAppName error:nil];
+    if(!username || !password) {
+        return NO;
+    }
+    
     [self requestLoginWithUsername:username andPassword:password completion:nil];
+    return YES;
 }
 
 - (void)requestLoginWithUsername:(NSString *)username andPassword:(NSString *)password completion:(void (^)(BOOL success, NSError *error))completion

--- a/docs/CHANGELOG.yml
+++ b/docs/CHANGELOG.yml
@@ -1,14 +1,18 @@
 upcoming:
-  version: 2.6.0
   notes:
-    - Fix email tint bug - jonallured
-    - Fix typo in editions - orta
-    - Consolidate navigation style between iPhone and iPad - orta
-    - Handle edition sets of 1 as not being multiple editions - orta
-    - iPhone artwork grids gets the ability to sort - orta
-    - Update to Xcode 9 - orta
+    - Crash fix on login - orta
 
 releases:
+  - version: 2.6.0
+    date: Apr 7, 2018
+    notes:
+      - Fix email tint bug - jonallured
+      - Fix typo in editions - orta
+      - Consolidate navigation style between iPhone and iPad - orta
+      - Handle edition sets of 1 as not being multiple editions - orta
+      - iPhone artwork grids gets the ability to sort - orta
+      - Update to Xcode 9 - orta
+
   - version: 2.5.5
     date: Apr 5, 2017
     notes:


### PR DESCRIPTION
I honestly have no idea how it could happen, but it must, somehow.

This crash is when either a username, or a password is not set, so it will now send the user to a login screen instead of letting them through into the app.

<img width="1224" alt="screen shot 2018-06-22 at 11 26 54 am" src="https://user-images.githubusercontent.com/49038/41784964-317fc132-760f-11e8-9fbf-e0dea22e164a.png">
