### PR TITLE
Bring back the settings sync progress

### DIFF
--- a/Classes/Controllers/Settings/ARSyncSettingsViewModel.h
+++ b/Classes/Controllers/Settings/ARSyncSettingsViewModel.h
@@ -1,8 +1,16 @@
 #import "ARSync.h"
 #import "ARNetworkQualityIndicator.h"
 
+@protocol ARSyncSettingsDelegate <NSObject>
+
+- (void)didUpdateNetworkQuality;
+- (void)didUpdateSyncPercent;
+- (void)syncDidFinish;
+
+@end
 
 @class ARSyncSettingsViewModel;
+
 
 @interface ARSyncSettingsViewModel : NSObject <ARSyncDelegate, ARSyncProgressDelegate>
 
@@ -11,6 +19,8 @@
 @property (nonatomic, assign) ARNetworkQuality networkQuality;
 @property (nonatomic, assign) CGFloat currentSyncPercentDone;
 @property (nonatomic, assign) NSTimeInterval timeRemainingInSync;
+
+@property (weak) id<ARSyncSettingsDelegate> settingsDelegate;
 
 - (instancetype)initWithSync:(ARSync *)sync context:(NSManagedObjectContext *)context;
 

--- a/Classes/Controllers/Settings/ARSyncSettingsViewModel.m
+++ b/Classes/Controllers/Settings/ARSyncSettingsViewModel.m
@@ -11,7 +11,6 @@
 @property (nonatomic, strong) NSUserDefaults *defaults;
 @property (nonatomic, strong) NSManagedObjectContext *context;
 @property (nonatomic, strong) ARSync *sync;
-
 @end
 
 
@@ -35,7 +34,11 @@
     self.networkQuality = ARNetworkQualityGood;
     self.qualityIndicator = qualityIndicator;
     [self.qualityIndicator beginObservingNetworkQuality:^(ARNetworkQuality quality) {
+        BOOL changed = self.networkQuality != quality;
         self.networkQuality = quality;
+        if (changed) {
+            [self.settingsDelegate didUpdateNetworkQuality];
+        }
     }];
 
     return self;
@@ -69,13 +72,14 @@
 {
     self.timeRemainingInSync = progress.estimatedTimeRemaining;
     self.currentSyncPercentDone = progress.percentDone;
-    NSLog(@"%@\%", @(progress.percentDone));
+    [self.settingsDelegate didUpdateSyncPercent];
 }
 
 - (void)syncDidFinish:(ARSync *)sync
 {
     self.currentSyncPercentDone = 1;
     self.timeRemainingInSync = 0;
+    [self.settingsDelegate syncDidFinish];
 }
 
 #pragma mark -

--- a/Podfile
+++ b/Podfile
@@ -31,7 +31,6 @@ target 'ArtsyFolio' do
 
     # Nicities
     pod 'ObjectiveSugar', :git => 'https://github.com/supermarin/ObjectiveSugar.git'
-    pod 'KVOController'
 
     # Networking
     pod 'Reachability', '~> 3.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -45,7 +45,6 @@ PODS:
   - JLRoutes (2.0.5)
   - JRSwizzle (1.0)
   - Keys (1.0.1)
-  - KVOController (1.2.0)
   - libextobjc/EXTKeyPathCoding (0.4.1):
     - libextobjc/RuntimeExtensions
   - libextobjc/EXTScope (0.4.1):
@@ -100,7 +99,6 @@ DEPENDENCIES:
   - ISO8601DateFormatter (~> 0.7)
   - JLRoutes
   - Keys (from `Pods/CocoaPodsKeys`)
-  - KVOController
   - libextobjc/EXTKeyPathCoding (~> 0.3)
   - libextobjc/EXTScope (~> 0.3)
   - ObjectiveSugar (from `https://github.com/supermarin/ObjectiveSugar.git`)
@@ -200,7 +198,6 @@ SPEC CHECKSUMS:
   JLRoutes: 2a5ee61d739b51a98c9d8112bee5149a19de8854
   JRSwizzle: dd5ead5d913a0f29e7f558200165849f006bb1e3
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
-  KVOController: d72ace34afea42468329623b3379ab3cd1d286b6
   libextobjc: a650fc1bf489a3d3a9bc2e621efa3e1006fc5471
   NSURL+QueryDictionary: bae616404e2adf6409d3d5c02a093cbf44c8a236
   ObjectiveSugar: 0729eb74a757ea48b109a8902178c9b89aa58a9f
@@ -219,6 +216,6 @@ SPEC CHECKSUMS:
   XCTest+OHHTTPStubSuiteCleanUp: 4469ec8863c6bc022c5089a9b94233eb3416c5ee
   ZipArchive: e25a4373192673e3229ac8d6e9f64a3e5713c966
 
-PODFILE CHECKSUM: 35a98566e4b358150384fd984198f8895b267bab
+PODFILE CHECKSUM: 71a515c3bb70a54c1f428b3187c5e725d72e2474
 
 COCOAPODS: 1.4.0

--- a/docs/CHANGELOG.yml
+++ b/docs/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
     - Visual tweaks (navbar line removed, white mode improvements)  - orta
     - Artwork detailed overview de-markdown fixes - orta
     - Login screen has better line-heights - orta
+    - Fix the un-changed progress indicators in settings - orta
 
 releases:
   - version: 2.6.0


### PR DESCRIPTION
I think an OS update, or tooling update broke the KVO controller we were using to separate the View Model from the View inside the settings page. There were no more updates to the lib, so I removed the dependency and switched to good old delegation.