### PR TITLE
Match the options for availabilities to CMS'

### DIFF
--- a/Classes/Contexts/Red Dot/ARPresentAvailabilityChoiceViewController.m
+++ b/Classes/Contexts/Red Dot/ARPresentAvailabilityChoiceViewController.m
@@ -11,20 +11,39 @@
 
 @implementation ARPresentAvailabilityChoiceViewController
 
-- (void)viewDidLoad
-{
-    [super viewDidLoad];
+// https://github.com/artsy/volt/blob/fee6fa7d4409276eaaee65370b27c1b6c5575e83/app/models/availability.rb#L3-L13
 
-    // Basically Green - Orange - Red - Grey
-    _orderedAvailabilities = @[
++ (NSArray *)orderedAvailabilitiesForPartnerType:(NSString *)type
+{
+    if ([type isEqualToString:@"Gallery"]) {
+        return @[
+            @(ARArtworkAvailabilityForSale),
+            @(ARArtworkAvailabilityOnHold),
+            @(ARArtworkAvailabilitySold),
+            @(ARArtworkAvailabilityNotForSale),
+        ];
+    } else if ([type isEqualToString:@"Private Collector"] || [type isEqualToString:@"Institution"]) {
+        return @[
+            @(ARArtworkAvailabilityOnLoan),
+            @(ARArtworkAvailabilityPermenentCollection)
+        ];
+    }
+
+    // Fallback to the gallery, you never know what the future data model could look like
+    return @[
         @(ARArtworkAvailabilityForSale),
         @(ARArtworkAvailabilityOnHold),
         @(ARArtworkAvailabilitySold),
         @(ARArtworkAvailabilityNotForSale),
-        @(ARArtworkAvailabilityOnLoan),
-        @(ARArtworkAvailabilityPermenentCollection)
     ];
+}
 
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+
+    _orderedAvailabilities = [self.class orderedAvailabilitiesForPartnerType:[Partner currentPartner].partnerType];
     [self.tableView registerClass:ARAvailabilityTableViewCell.class forCellReuseIdentifier:@"Cell"];
 }
 
@@ -35,7 +54,7 @@
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-    return ARArtworkAvilabilityCount;
+    return self.orderedAvailabilities.count;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
@@ -59,7 +78,7 @@
 {
     NSNumber *availability = self.orderedAvailabilities[indexPath.row];
 
-    for (int i = 0; i < ARArtworkAvilabilityCount; i++) {
+    for (int i = 0; i < [self tableView:tableView numberOfRowsInSection:0]; i++) {
         ARAvailabilityTableViewCell *cell = [tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:i inSection:0]];
         [cell setTickSelected:NO animated:NO];
     }
@@ -82,7 +101,7 @@
 
 - (CGSize)preferredContentSize
 {
-    return CGSizeMake(320, 20 + ARArtworkAvilabilityCount * 54);
+    return CGSizeMake(320, 20 + [self tableView:self.tableView numberOfRowsInSection:0] * 54);
 }
 
 @end

--- a/Classes/Models/Artwork.h
+++ b/Classes/Models/Artwork.h
@@ -15,9 +15,6 @@ typedef NS_ENUM(NSInteger, ARArtworkAvailability) {
     ARArtworkAvailabilityPermenentCollection,
 };
 
-// Used in editing availability
-static NSInteger ARArtworkAvilabilityCount = 6;
-
 
 @interface Artwork : _Artwork <ARGridViewItem, ARMultipleSelectionItem>
 

--- a/docs/CHANGELOG.yml
+++ b/docs/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
     - Crash fix on login - orta
     - Crash fix when sending an email with a keynote file - orta
     - Adds ability to enable/disable Folio for a particular subscriber  - orta
+    - The options for availabilities are matched to CMS' - orta
     - You can change an Artwork or EditionSets availability from the grid or an artwork  - orta
     - Visual tweaks (navbar line removed, white mode improvements)  - orta
     - Artwork detailed overview de-markdown fixes - orta

--- a/docs/THANKS.md
+++ b/docs/THANKS.md
@@ -1,8 +1,8 @@
 Thanks to all the contributors with 100+ commits in Energy, and from the 4 years of pre-OSS Energy:
 
-* Orta Therox - [orta](http://github.com/orta) - [@orta](http://twitter.com/orta)
-* Leonard Grey - [speednoisemovement](http://github.com/speednoisemovement) - [@speednoisemovement](http://twitter.com/speednoisemovement)
-* Sarah Scott - [sarahscott](http://github.com/sarahscott)
-* Benjamin Jackson - [benjaminjackson](http://github.com/benjaminjackson) - [@benjaminjackson](http://twitter.com.com/benjaminjackson)
-* Dustin Barker - [dstnbrkr](http://github.com/dstnbrkr) - [@dstnbrkr](http://twitter.com/dstnbrkr)
-* Claudiu-Vlad Ursache - [ursachec](http://github.com/ursachec) - [@ursachec](http://twitter.com/ursachec)
+* Orta Therox - [orta](https://github.com/orta) - [@orta](https://twitter.com/orta)
+* Leonard Grey - [speednoisemovement](https://github.com/speednoisemovement) - [@speednoisemovement](https://twitter.com/speednoisemovement)
+* Sarah Scott - [sarahscott](https://github.com/sarahscott)
+* Benjamin Jackson - [benjaminjackson](https://github.com/benjaminjackson) - [@benjaminjackson](https://twitter.com/benjaminjackson)
+* Dustin Barker - [dstnbrkr](https://github.com/dstnbrkr) - [@dstnbrkr](https://twitter.com/dstnbrkr)
+* Claudiu-Vlad Ursache - [ursachec](https://github.com/ursachec) - [@ursachec](https://twitter.com/ursachec)


### PR DESCRIPTION
In volt the options you can see for an artwork's availability is different depending. on the type of Partner you are. This makes Folio match them.

<img width="950" alt="Screen Shot 2019-04-01 at 11 15 32 AM" src="https://user-images.githubusercontent.com/49038/55339073-fa5cce80-546f-11e9-9f5b-ccc4fb5274af.png">
